### PR TITLE
Windows MPV Hang Fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "crossterm",
  "libc",
@@ -12,6 +12,7 @@ dependencies = [
  "rand 0.9.2",
  "ratatui",
  "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2347,6 +2348,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ rand = "0.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_System_JobObjects",
+    "Win32_Foundation",
+    "Win32_Security",
+] }

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -7,6 +7,9 @@ use std::os::unix::net::UnixStream;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
 #[cfg(unix)]
 use crate::audio::pipe as audio_pipe;
 use crate::audio::pipe::SharedAnalysis;
@@ -89,6 +92,9 @@ pub struct Player {
     has_parec: bool,
     /// Real-time stream information from mpv
     pub stream_info: StreamInfo,
+    /// Windows Job Object handle — kills mpv automatically if AetherTune is closed via X button
+    #[cfg(windows)]
+    job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
 }
 
 impl Player {
@@ -107,6 +113,9 @@ impl Player {
         #[cfg(windows)]
         let has_parec = false;
 
+        #[cfg(windows)]
+        let job_handle = create_kill_on_close_job();
+
         Self {
             process: None,
             #[cfg(unix)]
@@ -124,6 +133,8 @@ impl Player {
             request_counter: 0,
             has_parec,
             stream_info: StreamInfo::new(),
+            #[cfg(windows)]
+            job_handle,
         }
     }
 
@@ -154,6 +165,15 @@ impl Player {
 
         match cmd.spawn() {
             Ok(c) => {
+                // On Windows, assign mpv to our Job Object so it gets killed
+                // automatically if the terminal window is closed via the X button.
+                #[cfg(windows)]
+                {
+                    if let Some(job) = self.job_handle {
+                        assign_process_to_job(job, c.as_raw_handle());
+                    }
+                }
+
                 self.process = Some(c);
                 self.media_title = None;
                 self.stream_info.reset();
@@ -499,10 +519,61 @@ impl Player {
 impl Drop for Player {
     fn drop(&mut self) {
         self.stop();
+
+        #[cfg(windows)]
+        {
+            if let Some(job) = self.job_handle.take() {
+                unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+            }
+        }
     }
 }
 
 #[cfg(unix)]
 fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Create a Windows Job Object configured to kill all assigned processes
+/// when the last handle to the job is closed (i.e. when AetherTune exits).
+#[cfg(windows)]
+fn create_kill_on_close_job() -> Option<windows_sys::Win32::Foundation::HANDLE> {
+    use windows_sys::Win32::System::JobObjects::*;
+
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job == 0 {
+            return None;
+        }
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        let ok = SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &info as *const _ as *const _,
+            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        );
+
+        if ok == 0 {
+            windows_sys::Win32::Foundation::CloseHandle(job);
+            return None;
+        }
+
+        Some(job)
+    }
+}
+
+/// Assign a spawned process to a Job Object so it inherits the kill-on-close behavior.
+#[cfg(windows)]
+fn assign_process_to_job(
+    job: windows_sys::Win32::Foundation::HANDLE,
+    process: std::os::windows::io::RawHandle,
+) {
+    use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+
+    unsafe {
+        AssignProcessToJobObject(job, process as isize);
+    }
 }


### PR DESCRIPTION
On Windows, if the user closes the terminal window using the X button instead of pressing q, the mpv process continues running in the background. There's no visible indication that audio is still playing, and mpv doesn't show up in Task Manager's default "Apps" view. The only workaround is to manually kill it with `taskkill /IM mpv.exe`.

All new code is behind #[cfg(windows)] to keep the builds separate.

For testing, you should be able to:
- Build on Windows: cargo build
- Play a station and press q.  `mpv` should stop (existing behavior)
- Play a station then close terminal via X button. `mpv` should no longer remain running
- Check Task Manager after X-button close and there should be no orphaned `mpv.exe`

closes #1 