### PR TITLE
Add macOS support (playback + simulated visualizer)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,46 @@
+name: Build macOS
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build macOS (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            arch: x86_64
+          - target: aarch64-apple-darwin
+            runner: macos-14
+            arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Strip binary
+        run: strip target/${{ matrix.target }}/release/AetherTune
+
+      - name: Package binary
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          mkdir -p "AetherTune-${TAG}-macos-${{ matrix.arch }}"
+          cp target/${{ matrix.target }}/release/AetherTune "AetherTune-${TAG}-macos-${{ matrix.arch }}/"
+          cp README.md LICENSE "AetherTune-${TAG}-macos-${{ matrix.arch }}/"
+          tar czf "AetherTune-${TAG}-macos-${{ matrix.arch }}.tar.gz" "AetherTune-${TAG}-macos-${{ matrix.arch }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-${{ matrix.arch }}
+          path: AetherTune-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,12 @@ jobs:
   build-windows:
     uses: ./.github/workflows/build-windows.yml
 
+  build-macos:
+    uses: ./.github/workflows/build-macos.yml
+
   release:
     name: Create GitHub Release
-    needs: [build-linux, build-windows]
+    needs: [build-linux, build-windows, build-macos]
     runs-on: ubuntu-latest
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "AetherTune"
-version = "0.6.1-1"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -60,14 +60,39 @@ Currently available for Ubuntu Noble (24.04). Dependencies (`mpv`, `libpulse0`) 
 </details>
 
 <details>
-<summary><b>Linux — Homebrew</b></summary>
+<summary><b>Linux / macOS — Homebrew</b></summary>
 
 ```bash
 brew tap nevermore23274/aethertune
 brew install aethertune
 ```
 
-You'll also need `mpv` and `pulseaudio-utils` (or `pipewire-pulse`) installed on your system for playback and real-time audio visualization.
+You'll also need `mpv` installed on your system (`brew install mpv`). On Linux, you'll additionally need `pulseaudio-utils` (or `pipewire-pulse`) for real-time audio visualization.
+
+> **macOS note:** Audio visualization uses a simulated mode (no real-time audio capture yet). Playback, station browsing, favorites, and all other features work normally.
+
+</details>
+
+<details>
+<summary><b>macOS — Prebuilt binary</b></summary>
+
+Download the latest `.tar.gz` for your architecture from the [Releases page](https://github.com/nevermore23274/AetherTune/releases):
+
+```bash
+# Apple Silicon (M1/M2/M3/M4)
+curl -LO https://github.com/nevermore23274/AetherTune/releases/download/VERSION/AetherTune-VERSION-macos-aarch64.tar.gz
+tar xzf AetherTune-VERSION-macos-aarch64.tar.gz
+./AetherTune-VERSION-macos-aarch64/AetherTune
+
+# Intel
+curl -LO https://github.com/nevermore23274/AetherTune/releases/download/VERSION/AetherTune-VERSION-macos-x86_64.tar.gz
+tar xzf AetherTune-VERSION-macos-x86_64.tar.gz
+./AetherTune-VERSION-macos-x86_64/AetherTune
+```
+
+Replace `VERSION` with the actual tag (e.g. `v0.7.0`). You'll need `mpv` installed on your system (`brew install mpv`).
+
+> **macOS note:** Audio visualization uses a simulated mode. Playback and all other features work normally.
 
 </details>
 
@@ -114,9 +139,9 @@ home.packages = [ inputs.AetherTune.packages.${system}.aethertune ];
 </details>
 
 <details>
-<summary><b>Linux — From source</b></summary>
+<summary><b>Linux / macOS — From source</b></summary>
 
-Requires Rust 1.85+ and system dependencies (`mpv`, `pulseaudio-utils` or `pipewire-pulse`).
+Requires Rust 1.85+ and `mpv`. On Linux, you'll also need `pulseaudio-utils` or `pipewire-pulse` for real-time audio visualization.
 
 ```bash
 git clone https://github.com/nevermore23274/aethertune.git


### PR DESCRIPTION
- Add `build-macos.yml` for Intel (x86_64) and Apple Silicon (aarch64)
- Wire macOS builds into release.yml orchestrator
- No code changes needed as all platform gating uses `#[cfg(unix)]`
- `parec` check fails gracefully on macOS and simulated visualizer kicks in
- Update README with macOS installation instructions

Closes #10 #12 