### PR TITLE
perf: sliding window FFT reader for 2x update rate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "crossterm",
  "libc",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AetherTune is a TUI (terminal user interface) application that lets you browse, 
 
 - **Station browsing** — browse thousands of stations via the RadioBrowser API, filter by genre, search by name. Results are sorted by popularity with broken streams and spam filtered out automatically
 - **Local blending** — optionally configure your country code in Settings to blend ~30% local stations into every genre and search result, interleaved naturally with global results
-- **Real-time audio visualization** — 16-band spectrum analyzer using an in-place radix-2 FFT on captured PCM audio via PulseAudio/PipeWire monitor, with CAVA-inspired gravity fall-off, integral smoothing, and automatic sensitivity
+- **Real-time audio visualization** — 16-band spectrum analyzer using a sliding-window radix-2 FFT (~94 updates/sec) on captured PCM audio via PulseAudio/PipeWire monitor, with CAVA-inspired gravity fall-off, integral smoothing, and automatic sensitivity
 - **Song log** — automatically tracks song changes from ICY stream metadata with timestamps
 - **Stream health monitor** — live bitrate (actual vs advertised), buffer status, codec info, connection uptime
 - **Favorites & history** — save stations, track listening history, persisted to JSON
@@ -218,7 +218,8 @@ Below is a list of default keyboard shortcuts. All keybindings can be remapped f
 | `?`                    | Help overlay                                 |
 | `S`                    | Customize keybindings                        |
 | `` ` ``                | Performance profiler                         |
-| `<` / `>`              | Adjust tick rate (when profiler is open)     |
+| `<` / `>`              | Adjust tick rate (when profiler is open)      |
+| `{` / `}`              | Adjust visualizer smoothing (when profiler is open) |
 | `q`                    | Quit                                         |
 
 ## Settings
@@ -300,7 +301,7 @@ When `parec` is available, AetherTune captures audio through the PulseAudio/Pipe
 
 1. **mpv** plays audio normally through the default audio output
 2. **parec** captures the monitor source and writes raw s16le stereo 48kHz PCM to a named FIFO
-3. A background thread reads the FIFO with minimal buffering (one 4KB chunk ≈ 21ms of audio) and runs an **in-place radix-2 Cooley-Tukey FFT** with Hann windowing — producing 512 frequency bins that are grouped into 16 logarithmically-spaced bands (50Hz–10kHz). The FFT, window coefficients, and band edges are all pre-allocated at thread startup for zero per-frame heap allocation.
+3. A background thread reads the FIFO using a **sliding window** — 512 new samples (~10.7ms) at a time, shifted into a 1024-sample buffer — then runs an **in-place radix-2 Cooley-Tukey FFT** with Hann windowing. This produces ~94 FFT updates/sec (2× the rate of full-chunk reads) without sacrificing frequency resolution. The 512 frequency bins are grouped into 16 logarithmically-spaced bands (50Hz–10kHz). FFT buffers, window coefficients, and band edges are all pre-allocated at thread startup for zero per-frame heap allocation.
 4. Band energies and RMS are pushed to a shared `Arc<Mutex<AudioAnalysis>>`
 5. The visualizer applies CAVA-inspired post-processing: gravity fall-off (accelerating drop), integral smoothing (weighted running average), and automatic sensitivity adjustment
 

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -78,6 +78,7 @@ This section shows how quickly the visualizer bars react to changes in the audio
 ```
 Smoothing     70%  │  { } adjust
 Settling      7 frames  (~70ms @ 10ms tick)
+FFT rate      96/s  (~10.5ms per update)
 ```
 
 **Smoothing** is the noise reduction weight used in the visualizer's integral smoothing (an exponential moving average). Higher values produce smoother, more flowing bar animation but introduce visual lag. Lower values make bars snap to the audio faster but may look jittery. The default is 70% (CAVA uses 77%). Adjustable in 5% steps with `{` and `}`.
@@ -92,6 +93,8 @@ Settling      7 frames  (~70ms @ 10ms tick)
 | 95% | 45 | 450ms | 1350ms | Flowing but sluggish |
 
 The smoothing value is runtime-only and resets to the default (70%) on restart.
+
+**FFT rate** shows how many FFT updates per second the audio reader thread is producing. The reader uses a sliding window — it reads 512 new samples (~10.7ms of audio at 48kHz) at a time, shifts the 1024-sample buffer, and runs a full FFT on the window. This produces ~94 updates/sec, roughly 2× what a full 1024-sample read would give (~47/s), without sacrificing frequency resolution. Color coding: green ≥80/s, yellow ≥40/s, red below. Shows "—" when no audio capture is active (e.g., on Windows or when parec is unavailable).
 
 ### The avg and max Columns
 
@@ -140,21 +143,26 @@ Each frame records a `had_tick` flag indicating whether the IPC poll and visuali
 
 The sparkline records one CPU load sample per frame into a separate 40-entry ring buffer, displayed oldest-to-newest.
 
+### Audio Reader (Sliding Window)
+
+The `parec` reader thread uses a sliding window to maximize FFT update rate without sacrificing frequency resolution. Instead of reading a full 1024-sample chunk (~21ms at 48kHz) before running FFT, it reads 512 new samples (~10.7ms), shifts the 1024-sample buffer left, and runs FFT on the full window. This produces ~94 FFT updates/sec — 2× the rate of full-chunk reads — while keeping the same 1024-point FFT resolution. The `fft_count` field on `AudioAnalysis` is incremented on each update, and the profiler computes the rate by sampling this counter every ~1 second.
+
 ## Reference Benchmarks
 
 Measured on a Ryzen 9 5900X running Hyprland/PipeWire, kitty terminal, streaming 192kbps MP3 with real audio visualization active:
 
-| Tick rate | FPS | Avg draw | Avg work | CPU load | Status |
-|-----------|-----|----------|----------|----------|--------|
-| 10ms | 100 | ~5,500µs | ~5,550µs | 55% | OK |
-| 20ms | 50 | ~5,500µs | ~5,550µs | 27% | IDLE |
-| 30ms | 33 | ~5,500µs | ~5,550µs | 18% | IDLE |
-| 50ms | 20 | ~5,500µs | ~5,550µs | 11% | IDLE |
+| Tick rate | FPS | Avg draw | Avg work | CPU load | FFT rate | Status |
+|-----------|-----|----------|----------|----------|----------|--------|
+| 10ms | 100 | ~5,700µs | ~5,770µs | 57% | ~96/s | OK |
+| 20ms | 50 | ~5,500µs | ~5,550µs | 27% | ~96/s | IDLE |
+| 30ms | 33 | ~5,500µs | ~5,550µs | 18% | ~96/s | IDLE |
+| 50ms | 20 | ~5,500µs | ~5,550µs | 11% | ~96/s | IDLE |
 
 Key observations:
 
-- **Draw cost is constant** (~5.5ms) regardless of tick rate. It dominates the work budget.
+- **Draw cost is constant** (~5.5–5.7ms) regardless of tick rate. It dominates the work budget.
 - **IPC poll and visualizer** are negligible (20–80µs combined on tick frames).
+- **FFT rate is constant** (~96/s) regardless of tick rate — the reader thread runs independently.
 - **Load scales inversely with tick rate** since the same work runs against a larger budget.
 - **30ms (33 FPS)** is the default — good balance of visualizer smoothness vs resource usage.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -405,6 +405,12 @@ pub struct App {
     pub show_perf: bool,
     /// Current tick rate in ms (adjustable with < > keys when perf overlay is shown)
     pub tick_rate_ms: u64,
+    /// FFT updates per second (measured from the reader thread's fft_count)
+    pub fft_rate: f64,
+    /// Previous fft_count snapshot for computing rate
+    fft_count_prev: u64,
+    /// Timestamp of last FFT rate measurement
+    fft_rate_time: std::time::Instant,
     /// Country code for blended local/global station discovery (from config)
     pub country_code: String,
     /// Remappable keybindings (persisted to config)
@@ -505,6 +511,9 @@ impl App {
             perf: PerfStats::new(),
             show_perf: false,
             tick_rate_ms: config.tick_rate_ms,
+            fft_rate: 0.0,
+            fft_count_prev: 0,
+            fft_rate_time: std::time::Instant::now(),
             country_code: config.country_code.clone(),
             keybindings: config.keybindings,
             settings_selected: 0,
@@ -925,6 +934,24 @@ impl App {
                 }
             }
             self.last_media_title = current_title;
+        }
+    }
+
+    /// Update the FFT updates/sec measurement.
+    /// Called each tick; computes rate over the elapsed interval.
+    pub fn update_fft_rate(&mut self) {
+        let now = std::time::Instant::now();
+        let elapsed = now.duration_since(self.fft_rate_time).as_secs_f64();
+
+        // Update every ~1 second to avoid jittery measurements
+        if elapsed >= 1.0 {
+            if let Ok(a) = self.analysis.lock() {
+                let count = a.fft_count;
+                let delta = count.saturating_sub(self.fft_count_prev);
+                self.fft_rate = delta as f64 / elapsed;
+                self.fft_count_prev = count;
+            }
+            self.fft_rate_time = now;
         }
     }
 

--- a/src/audio/pipe.rs
+++ b/src/audio/pipe.rs
@@ -20,6 +20,8 @@ pub struct AudioAnalysis {
     pub rms: f64,
     /// Whether the reader is actively receiving data
     pub active: bool,
+    /// Total number of FFT updates since the reader started
+    pub fft_count: u64,
 }
 
 impl AudioAnalysis {
@@ -28,6 +30,7 @@ impl AudioAnalysis {
             bands: [0.0; NUM_BANDS],
             rms: 0.0,
             active: false,
+            fft_count: 0,
         }
     }
 }
@@ -81,17 +84,22 @@ fn reader_loop(fifo: &std::path::Path, analysis: &SharedAnalysis) {
         Err(_) => return,
     };
 
-    // Minimal buffering — just enough for one chunk to reduce latency.
-    // At 48kHz stereo s16le: 4 bytes per frame, 1024 frames = 4096 bytes.
-    // Previous 16KB buffer could hold ~4 chunks, adding ~80ms of delay.
-    const FRAMES: usize = FFT_SIZE;
+    // Sliding window approach: read STEP_FRAMES new samples at a time,
+    // shift the sample buffer, and run FFT on the full FFT_SIZE window.
+    // This doubles the FFT update rate without reducing frequency resolution.
+    //
+    // At 48kHz stereo s16le:
+    //   FFT_SIZE  = 1024 samples = 4096 bytes = ~21.3ms (full window)
+    //   STEP      =  512 samples = 2048 bytes = ~10.7ms (read chunk)
+    //   FFT rate  = 48000 / 512  = ~94 updates/sec (vs ~47 with full reads)
+    const STEP_FRAMES: usize = FFT_SIZE / 2;
     const BYTES_PER_FRAME: usize = 4; // 2 channels * 2 bytes (s16le)
-    const CHUNK_SIZE: usize = FRAMES * BYTES_PER_FRAME;
+    const STEP_BYTES: usize = STEP_FRAMES * BYTES_PER_FRAME;
 
-    let mut reader = std::io::BufReader::with_capacity(CHUNK_SIZE, file);
+    let mut reader = std::io::BufReader::with_capacity(STEP_BYTES, file);
 
-    let mut buf = vec![0u8; CHUNK_SIZE];
-    let mut mono_samples = vec![0.0f64; FRAMES];
+    let mut read_buf = vec![0u8; STEP_BYTES];
+    let mut mono_samples = vec![0.0f64; FFT_SIZE];
 
     // Pre-allocate FFT work buffers to avoid per-frame allocation
     let mut fft_re = vec![0.0f64; FFT_SIZE];
@@ -107,8 +115,8 @@ fn reader_loop(fifo: &std::path::Path, analysis: &SharedAnalysis) {
     let band_edges = compute_band_edges();
 
     loop {
-        // Read a full chunk
-        match reader.read_exact(&mut buf) {
+        // Read a half-window chunk (512 samples = 2048 bytes)
+        match reader.read_exact(&mut read_buf) {
             Ok(()) => {}
             Err(_) => {
                 // FIFO closed or error — mpv stopped
@@ -121,18 +129,21 @@ fn reader_loop(fifo: &std::path::Path, analysis: &SharedAnalysis) {
             }
         }
 
-        // Convert s16le stereo to mono f64 samples
-        for i in 0..FRAMES {
+        // Shift the sample buffer left by STEP_FRAMES (discard oldest half)
+        mono_samples.copy_within(STEP_FRAMES.., 0);
+
+        // Convert new s16le stereo samples to mono f64 and fill the second half
+        for i in 0..STEP_FRAMES {
             let offset = i * BYTES_PER_FRAME;
-            let left = i16::from_le_bytes([buf[offset], buf[offset + 1]]) as f64;
-            let right = i16::from_le_bytes([buf[offset + 2], buf[offset + 3]]) as f64;
-            mono_samples[i] = (left + right) / 2.0 / 32768.0; // normalize to -1..1
+            let left = i16::from_le_bytes([read_buf[offset], read_buf[offset + 1]]) as f64;
+            let right = i16::from_le_bytes([read_buf[offset + 2], read_buf[offset + 3]]) as f64;
+            mono_samples[FFT_SIZE - STEP_FRAMES + i] = (left + right) / 2.0 / 32768.0;
         }
 
-        // Compute overall RMS
+        // Compute overall RMS on the full window
         let rms = {
             let sum_sq: f64 = mono_samples.iter().map(|s| s * s).sum();
-            (sum_sq / FRAMES as f64).sqrt()
+            (sum_sq / FFT_SIZE as f64).sqrt()
         };
 
         // Apply Hann window and load into FFT real buffer, zero imaginary
@@ -157,6 +168,7 @@ fn reader_loop(fifo: &std::path::Path, analysis: &SharedAnalysis) {
             a.active = true;
             a.rms = rms;
             a.bands = band_energies;
+            a.fft_count += 1;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Check if a background station fetch has completed
             app.poll_fetch();
 
+            // Update FFT rate measurement for profiler
+            app.update_fft_rate();
+
             poll_us = poll_start.elapsed().as_micros() as u64;
 
             let vis_start = Instant::now();

--- a/src/ui/perf_overlay.rs
+++ b/src/ui/perf_overlay.rs
@@ -147,6 +147,38 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(Color::Rgb(100, 100, 130)),
         ),
     ]));
+    let fft_rate = app.fft_rate;
+    let fft_color = if fft_rate < 1.0 {
+        Color::Rgb(100, 100, 130) // inactive/no data
+    } else if fft_rate >= 80.0 {
+        NEON_GREEN
+    } else if fft_rate >= 40.0 {
+        YELLOW
+    } else {
+        RED
+    };
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("  FFT rate      "),
+            Style::default().fg(Color::Rgb(140, 140, 160)),
+        ),
+        Span::styled(
+            if fft_rate < 1.0 {
+                "—".to_string()
+            } else {
+                format!("{:.0}/s", fft_rate)
+            },
+            Style::default().fg(fft_color),
+        ),
+        Span::styled(
+            if fft_rate < 1.0 {
+                "  (no audio capture)".to_string()
+            } else {
+                format!("  (~{:.1}ms per update)", 1000.0 / fft_rate)
+            },
+            Style::default().fg(Color::Rgb(100, 100, 130)),
+        ),
+    ]));
     lines.push(Line::from(""));
 
     // Totals


### PR DESCRIPTION
- FIFO reader now reads 512 samples (~10.7ms) at a time instead of 1024 (~21.3ms), shifts the sample buffer, and runs FFT on the full 1024-sample window. This doubles the FFT update rate from ~47/s to ~94/s without reducing frequency resolution.
- Added fft_count field to AudioAnalysis, incremented on each FFT
- New FFT rate metric in profiler (updates/sec + ms per update)
- Updated PROFILING.md with FFT rate docs, sliding window architecture, and refreshed benchmark table
- Updated README with sliding window in feature list and pipeline
- Closes #16