### PR TITLE
feat: theme system with 8 built-in themes + picker overlay (v0.7.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "AetherTune"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Below is a list of default keyboard shortcuts. All keybindings can be remapped f
 | `[` / `]`              | Cycle genre category                         |
 | `Shift+Tab`            | Cycle genre category (backward)              |
 | `g`                    | Genre picker overlay                         |
+| `t`                    | Theme picker overlay                         |
 | `?`                    | Help overlay                                 |
 | `S`                    | Customize keybindings                        |
 | `` ` ``                | Performance profiler                         |
@@ -237,6 +238,21 @@ Leave the country code empty (backspace to clear) for pure global results — th
 ### Keybindings
 
 Every keyboard shortcut can be remapped. Press `S` during normal playback to open the keybinding settings overlay.
+
+### Themes
+
+Press `t` to open the theme picker. AetherTune ships with 8 built-in themes:
+
+- **CRT** — the default phosphor terminal aesthetic (cyan/magenta/neon green)
+- **Gruvbox** — warm retro palette
+- **Nord** — cool arctic blues
+- **Dracula** — dark purple
+- **Monokai** — classic editor colors
+- **Catppuccin** — pastel dark
+- **Hacker** — green-on-black matrix style
+- **Solarized** — precision colors for readability
+
+Themes apply to the player UI only (not the launcher or exit animation). Your selection is persisted to `~/.aethertune/config.json`. The theme picker shows live color swatches and previews each theme as you navigate.
 
 In the overlay:
 - **↑/↓** — navigate the action list
@@ -290,6 +306,8 @@ src/
     ├── media_browser.rs      Media source switcher (Radio/Subsonic stub)
     ├── overlays.rs           Help + station detail popups
     ├── genre_picker.rs       Genre selection overlay
+    ├── theme_picker.rs       Theme selection overlay
+    ├── themes.rs             Color theme definitions (8 built-in themes)
     ├── settings.rs           Keybinding settings overlay
     ├── shutdown.rs           CRT power-off animation on quit
     └── perf_overlay.rs       Built-in performance profiler

--- a/src/app.rs
+++ b/src/app.rs
@@ -204,6 +204,7 @@ pub enum Overlay {
     StationDetail,
     Settings,
     GenrePicker,
+    ThemePicker,
 }
 
 /// Lightweight per-frame performance counters.
@@ -426,6 +427,10 @@ pub struct App {
     pub pending_fetch: Option<oneshot::Receiver<FetchResult>>,
     /// Currently selected index in the genre picker overlay
     pub genre_selected: usize,
+    /// Active color theme for the player UI
+    pub theme: crate::ui::themes::Theme,
+    /// Currently selected index in the theme picker overlay
+    pub theme_selected: usize,
 }
 
 #[derive(Clone)]
@@ -521,6 +526,11 @@ impl App {
             is_loading: false,
             pending_fetch: None,
             genre_selected: 0,
+            theme: crate::ui::themes::Theme::by_name(&config.theme),
+            theme_selected: {
+                let all = crate::ui::themes::Theme::all();
+                all.iter().position(|t| t.name.eq_ignore_ascii_case(&config.theme)).unwrap_or(0)
+            },
         }
     }
 
@@ -712,6 +722,7 @@ impl App {
         config.tick_rate_ms = self.tick_rate_ms;
         config.volume = self.volume;
         config.keybindings = self.keybindings.clone();
+        config.theme = self.theme.name.to_string();
         config.save();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 match app.input_mode {
                     InputMode::Normal => {
+                        // ── Theme picker overlay ──
+                        if app.overlay == Overlay::ThemePicker {
+                            let themes = crate::ui::themes::Theme::all();
+                            let total = themes.len();
+                            match key.code {
+                                KeyCode::Esc => {
+                                    app.overlay = Overlay::None;
+                                }
+                                _ if app.keybindings.theme_picker.matches(key.code) => {
+                                    app.overlay = Overlay::None;
+                                }
+                                KeyCode::Up | KeyCode::Char('k') => {
+                                    if app.theme_selected > 0 {
+                                        app.theme_selected -= 1;
+                                        // Live preview
+                                        app.theme = themes.into_iter().nth(app.theme_selected).unwrap();
+                                    }
+                                }
+                                KeyCode::Down | KeyCode::Char('j') => {
+                                    if app.theme_selected < total - 1 {
+                                        app.theme_selected += 1;
+                                        // Live preview
+                                        app.theme = themes.into_iter().nth(app.theme_selected).unwrap();
+                                    }
+                                }
+                                KeyCode::Enter => {
+                                    app.theme = themes.into_iter().nth(app.theme_selected).unwrap();
+                                    app.save_config();
+                                    app.overlay = Overlay::None;
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
+
                         // ── Genre picker overlay ──
                         if app.overlay == Overlay::GenrePicker {
                             match key.code {
@@ -247,6 +282,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         } else if app.keybindings.genre_picker.matches(kc) {
                             app.genre_selected = app.category_index;
                             app.overlay = Overlay::GenrePicker;
+                        } else if app.keybindings.theme_picker.matches(kc) {
+                            // Open theme picker overlay
+                            let themes = crate::ui::themes::Theme::all();
+                            app.theme_selected = themes.iter()
+                                .position(|t| t.name == app.theme.name)
+                                .unwrap_or(0);
+                            app.overlay = Overlay::ThemePicker;
                         } else if app.keybindings.search.matches(kc) {
                             app.search_query.clear();
                             app.input_mode = InputMode::Editing;

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -45,6 +45,7 @@ pub struct KeyBindings {
     pub genre_next: KeyBinding,
     pub genre_prev: KeyBinding,
     pub genre_picker: KeyBinding,
+    pub theme_picker: KeyBinding,
     pub help: KeyBinding,
     pub perf_toggle: KeyBinding,
     pub perf_tick_slower: KeyBinding,
@@ -71,6 +72,7 @@ impl KeyBindings {
             ("genre_next",       "Next Genre",          &self.genre_next),
             ("genre_prev",       "Previous Genre",      &self.genre_prev),
             ("genre_picker",     "Genre Picker",        &self.genre_picker),
+            ("theme_picker",     "Theme Picker",        &self.theme_picker),
             ("help",             "Help Overlay",        &self.help),
             ("perf_toggle",      "Perf Profiler",       &self.perf_toggle),
             ("perf_tick_slower",  "Tick Rate Slower",   &self.perf_tick_slower),
@@ -97,6 +99,7 @@ impl KeyBindings {
             "genre_next"       => &mut self.genre_next,
             "genre_prev"       => &mut self.genre_prev,
             "genre_picker"     => &mut self.genre_picker,
+            "theme_picker"     => &mut self.theme_picker,
             "help"             => &mut self.help,
             "perf_toggle"      => &mut self.perf_toggle,
             "perf_tick_slower"  => &mut self.perf_tick_slower,
@@ -132,6 +135,7 @@ impl Default for KeyBindings {
             genre_next:       KeyBinding::new(KeyCode::Char(']')),
             genre_prev:       KeyBinding::new(KeyCode::Char('[')),
             genre_picker:     KeyBinding::new(KeyCode::Char('g')),
+            theme_picker:     KeyBinding::new(KeyCode::Char('t')),
             help:             KeyBinding::new(KeyCode::Char('?')),
             perf_toggle:      KeyBinding::new(KeyCode::Char('`')),
             perf_tick_slower:  KeyBinding::with_alt(KeyCode::Char('<'), KeyCode::Char(',')),
@@ -211,6 +215,8 @@ pub struct Config {
     /// Empty string means no local blending (global results only).
     pub country_code: String,
     pub keybindings: KeyBindings,
+    /// Theme name (e.g. "CRT", "Gruvbox", "Nord")
+    pub theme: String,
     path: PathBuf,
 }
 
@@ -239,7 +245,9 @@ impl Config {
                 let country_code = Self::extract_string(&contents, "country_code")
                     .unwrap_or_default();
                 let keybindings = Self::load_keybindings(&contents);
-                return Self { tick_rate_ms, volume, country_code, keybindings, path };
+                let theme = Self::extract_string(&contents, "theme")
+                    .unwrap_or_else(|| "CRT".to_string());
+                return Self { tick_rate_ms, volume, country_code, keybindings, theme, path };
             }
         }
         Self {
@@ -247,6 +255,7 @@ impl Config {
             volume: DEFAULT_VOLUME,
             country_code: String::new(),
             keybindings: KeyBindings::default(),
+            theme: "CRT".to_string(),
             path,
         }
     }
@@ -294,9 +303,11 @@ impl Config {
             format!("{{\n{}\n    }}", kb_lines.join(",\n"))
         };
 
+        let theme_escaped = self.theme.replace('\\', "\\\\").replace('"', "\\\"");
+
         let json = format!(
-            "{{\n  \"tick_rate_ms\": {},\n  \"volume\": {},\n  \"country_code\": \"{}\",\n    \"keybindings\": {}\n}}",
-            self.tick_rate_ms, self.volume, cc_escaped, kb_json
+            "{{\n  \"tick_rate_ms\": {},\n  \"volume\": {},\n  \"country_code\": \"{}\",\n  \"theme\": \"{}\",\n    \"keybindings\": {}\n}}",
+            self.tick_rate_ms, self.volume, cc_escaped, theme_escaped, kb_json
         );
         let _ = fs::write(&self.path, json);
     }

--- a/src/ui/genre_picker.rs
+++ b/src/ui/genre_picker.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -40,7 +40,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     lines.push(Line::from(Span::styled(
         "♫  Select Genre",
-        Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+        Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::from(""));
 
@@ -59,13 +59,13 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         let is_active = i == app.category_index;
 
         let (indicator, bg, fg) = if is_selected && is_active {
-            ("▸ ", ACTIVE_BG, NEON_GREEN)
+            ("▸ ", ACTIVE_BG, app.theme.positive)
         } else if is_selected {
             ("▸ ", SELECTED_BG, Color::White)
         } else if is_active {
-            ("  ", ACTIVE_BG, NEON_GREEN)
+            ("  ", ACTIVE_BG, app.theme.positive)
         } else {
-            ("  ", Color::Reset, DIM_WHITE)
+            ("  ", Color::Reset, app.theme.text_muted)
         };
 
         let suffix = if is_active { " ●" } else { "" };
@@ -92,22 +92,22 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         Style::default().fg(Color::Rgb(50, 50, 70)),
     )));
     lines.push(Line::from(vec![
-        Span::styled("  ↑/↓", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-        Span::styled(" nav  ", Style::default().fg(DIM_WHITE)),
-        Span::styled("Enter", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-        Span::styled(" select  ", Style::default().fg(DIM_WHITE)),
-        Span::styled("Esc", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-        Span::styled(" close", Style::default().fg(DIM_WHITE)),
+        Span::styled("  ↑/↓", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" nav  ", Style::default().fg(app.theme.text_muted)),
+        Span::styled("Enter", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" select  ", Style::default().fg(app.theme.text_muted)),
+        Span::styled("Esc", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" close", Style::default().fg(app.theme.text_muted)),
     ]));
 
     let block = Block::default()
         .title(Span::styled(
             " Genre ",
-            Style::default().fg(MAGENTA).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.secondary).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(MAGENTA))
+        .border_style(Style::default().fg(app.theme.secondary))
         .padding(Padding::new(1, 1, 1, 1))
         .style(Style::default().bg(Color::Rgb(10, 10, 20)));
 

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,5 +1,5 @@
 use crate::app::{App, InputMode};
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -12,17 +12,17 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     if app.input_mode == InputMode::Editing {
         // Search mode: show search input
         let search_line = Line::from(vec![
-            Span::styled(" 🔍 > ", Style::default().fg(YELLOW)),
+            Span::styled(" 🔍 > ", Style::default().fg(app.theme.text_warn)),
             Span::styled(
                 format!("{}_", app.search_query),
-                Style::default().fg(YELLOW),
+                Style::default().fg(app.theme.text_warn),
             ),
         ]);
 
-        let block = header_block();
+        let block = header_block(&app.theme);
         let paragraph = Paragraph::new(search_line)
             .block(block)
-            .style(Style::default().bg(PANEL_BG));
+            .style(Style::default().bg(app.theme.bg_panel));
         f.render_widget(paragraph, area);
     } else {
         // Normal mode: LIVE indicator + genre + hints
@@ -31,7 +31,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 " ▶ LIVE ",
                 Style::default()
                     .fg(Color::Black)
-                    .bg(NEON_GREEN)
+                    .bg(app.theme.positive)
                     .add_modifier(Modifier::BOLD),
             )
         } else {
@@ -48,6 +48,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         use crate::storage::config::keycode_to_string;
         let search_key = keycode_to_string(app.keybindings.search.primary);
         let genre_key = keycode_to_string(app.keybindings.genre_picker.primary);
+        let theme_key = keycode_to_string(app.keybindings.theme_picker.primary);
         let help_key = keycode_to_string(app.keybindings.help.primary);
         let settings_key = keycode_to_string(app.keybindings.settings.primary);
 
@@ -56,34 +57,34 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
             playing_indicator,
             Span::styled(
                 format!("  Genre: {}", cat),
-                Style::default().fg(CYAN),
+                Style::default().fg(app.theme.accent),
             ),
             Span::styled(
-                format!("  │  {} search  │  {} genre  │  {} help  │  {} settings", search_key, genre_key, help_key, settings_key),
+                format!("  │  {} search  │  {} genre  │  {} theme  │  {} help  │  {} settings", search_key, genre_key, theme_key, help_key, settings_key),
                 Style::default().fg(Color::Rgb(80, 80, 110)),
             ),
         ]);
 
-        let block = header_block();
+        let block = header_block(&app.theme);
         let paragraph = Paragraph::new(line)
             .block(block)
-            .style(Style::default().bg(PANEL_BG));
+            .style(Style::default().bg(app.theme.bg_panel));
         f.render_widget(paragraph, area);
     }
 }
 
-fn header_block() -> Block<'static> {
+fn header_block(theme: &crate::ui::themes::Theme) -> Block<'static> {
     Block::default()
         .title(Line::from(vec![
-            Span::styled(" 🎵 ", Style::default().fg(MAGENTA)),
+            Span::styled(" 🎵 ", Style::default().fg(theme.secondary)),
             Span::styled(
                 "AetherTune",
-                Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
             ),
             Span::styled(" ", Style::default()),
         ]))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
-        .style(Style::default().bg(PANEL_BG))
+        .style(Style::default().bg(theme.bg_panel))
 }

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -27,15 +27,17 @@ pub fn info_line(label: &str, value: &str, color: Color) -> Line<'static> {
     ])
 }
 
-pub fn volume_line(volume: u32) -> Line<'static> {
+use crate::ui::themes::Theme;
+
+pub fn volume_line(volume: u32, theme: &Theme) -> Line<'static> {
     let filled = (volume as usize * 20) / 100;
     let empty = 20 - filled;
     let bar_color = if volume > 80 {
-        RED
+        theme.text_error
     } else if volume > 50 {
-        YELLOW
+        theme.text_warn
     } else {
-        NEON_GREEN
+        theme.positive
     };
 
     Line::from(vec![
@@ -54,13 +56,13 @@ pub fn volume_line(volume: u32) -> Line<'static> {
     ])
 }
 
-pub fn help_line(key: &str, desc: &str) -> Line<'static> {
+pub fn help_line_themed(key: &str, desc: &str, theme: &Theme) -> Line<'static> {
     Line::from(vec![
         Span::styled(
             format!("  {:<14}", key),
-            Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.positive).add_modifier(Modifier::BOLD),
         ),
-        Span::styled(desc.to_string(), Style::default().fg(DIM_WHITE)),
+        Span::styled(desc.to_string(), Style::default().fg(theme.text_muted)),
     ])
 }
 

--- a/src/ui/media_browser.rs
+++ b/src/ui/media_browser.rs
@@ -47,7 +47,7 @@
 // ──────────────────────────────────────────────────────────────────────
 
 use crate::app::App;
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -56,12 +56,12 @@ use ratatui::{
     layout::Rect,
 };
 
-pub fn draw(f: &mut Frame, _app: &App, area: Rect) {
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     // Source tabs
     let radio_tab = Span::styled(
         " ● Radio ",
         Style::default()
-            .fg(NEON_GREEN)
+            .fg(app.theme.positive)
             .add_modifier(Modifier::BOLD),
     );
     let subsonic_tab = Span::styled(
@@ -88,7 +88,7 @@ pub fn draw(f: &mut Frame, _app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
         .padding(Padding::new(1, 1, 0, 0))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let inner = block.inner(area);
     f.render_widget(block, area);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,10 +11,11 @@ pub mod shutdown;
 pub mod song_log;
 pub mod station_list;
 pub mod stream_info;
+pub mod themes;
+pub mod theme_picker;
 pub mod visualizer;
 
 use crate::app::{App, Overlay};
-use helpers::DARK_BG;
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
@@ -25,9 +26,9 @@ use ratatui::{
 pub fn draw(f: &mut Frame, app: &App) {
     let size = f.size();
 
-    // Fill background
+    // Fill background with theme color
     f.render_widget(
-        Block::default().style(Style::default().bg(DARK_BG)),
+        Block::default().style(Style::default().bg(app.theme.bg_dark)),
         size,
     );
 
@@ -49,6 +50,7 @@ pub fn draw(f: &mut Frame, app: &App) {
         Overlay::StationDetail => overlays::draw_detail(f, app, size),
         Overlay::Settings => settings::draw(f, app, size),
         Overlay::GenrePicker => genre_picker::draw(f, app, size),
+        Overlay::ThemePicker => theme_picker::draw(f, app, size),
         Overlay::None => {}
     }
 

--- a/src/ui/now_playing.rs
+++ b/src/ui/now_playing.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use super::helpers::*;
+use super::helpers::info_line;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -15,13 +15,13 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .title(Span::styled(
             " Now Playing ",
-            Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
         .padding(Padding::new(1, 1, 0, 0))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -36,7 +36,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 buf.get_mut(x, area.y)
                     .set_char(ch)
                     .set_fg(Color::Rgb(100, 100, 140))
-                    .set_bg(PANEL_BG);
+                    .set_bg(app.theme.bg_panel);
             }
         }
     }
@@ -49,7 +49,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     if let Some(np) = &app.now_playing {
         lines.push(Line::from(vec![
-            Span::styled("♪ ", Style::default().fg(NEON_GREEN)),
+            Span::styled("♪ ", Style::default().fg(app.theme.positive)),
             Span::styled(
                 np.name.clone(),
                 Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
@@ -62,17 +62,17 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                     Span::styled("  ▸ ", Style::default().fg(Color::Rgb(80, 80, 120))),
                     Span::styled(
                         title.clone(),
-                        Style::default().fg(YELLOW).add_modifier(Modifier::ITALIC),
+                        Style::default().fg(app.theme.text_warn).add_modifier(Modifier::ITALIC),
                     ),
                 ]));
             }
         }
 
         lines.push(Line::from(""));
-        lines.push(info_line("Genre", &np.genre, MAGENTA));
-        lines.push(info_line("Country", &np.country, CYAN));
-        lines.push(info_line("Bitrate", &format!("{} kbps", np.bitrate), YELLOW));
-        lines.push(info_line("Codec", &np.codec, ORANGE));
+        lines.push(info_line("Genre", &np.genre, app.theme.secondary));
+        lines.push(info_line("Country", &np.country, app.theme.accent));
+        lines.push(info_line("Bitrate", &format!("{} kbps", np.bitrate), app.theme.text_warn));
+        lines.push(info_line("Codec", &np.codec, app.theme.text_warm));
 
         if !np.homepage.is_empty() {
             lines.push(info_line("Web", &np.homepage, Color::Rgb(100, 150, 255)));
@@ -81,12 +81,12 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "⚠ Playback Error",
-            Style::default().fg(RED).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_error).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             err.clone(),
-            Style::default().fg(YELLOW),
+            Style::default().fg(app.theme.text_warn),
         )));
     } else {
         lines.push(Line::from(""));

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -1,6 +1,6 @@
 use crate::app::{ActivePanel, App};
 use crate::storage::config::binding_display;
-use super::helpers::*;
+use super::helpers::{help_line_themed, info_line, centered_rect};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -17,29 +17,30 @@ pub fn draw_help(f: &mut Frame, app: &App, area: Rect) {
     let help_text = vec![
         Line::from(Span::styled(
             "⌨  Keybindings",
-            Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        help_line(&binding_display(&kb.navigate_up), "Navigate up"),
-        help_line(&binding_display(&kb.navigate_down), "Navigate down"),
-        help_line(&binding_display(&kb.play), "Play selected station"),
-        help_line(&binding_display(&kb.stop), "Stop playback"),
-        help_line(&binding_display(&kb.volume_up), "Volume up"),
-        help_line(&binding_display(&kb.volume_down), "Volume down"),
-        help_line(&binding_display(&kb.search), "Search stations"),
-        help_line(&binding_display(&kb.toggle_favorite), "Toggle favorite"),
-        help_line(&binding_display(&kb.station_detail), "Station details"),
-        help_line(&binding_display(&kb.load_more), "Load more stations"),
-        help_line(&binding_display(&kb.cycle_panel), "Cycle panel"),
-        help_line(&binding_display(&kb.genre_next), "Next genre"),
-        help_line(&binding_display(&kb.genre_prev), "Previous genre"),
-        help_line(&binding_display(&kb.genre_picker), "Genre picker"),
-        help_line(&binding_display(&kb.help), "Toggle this help"),
-        help_line(&binding_display(&kb.perf_toggle), "Performance profiler"),
-        help_line(&binding_display(&kb.perf_tick_slower), "Tick rate slower (profiler)"),
-        help_line(&binding_display(&kb.perf_tick_faster), "Tick rate faster (profiler)"),
-        help_line(&binding_display(&kb.settings), "Keybinding settings"),
-        help_line(&binding_display(&kb.quit), "Quit"),
+        help_line_themed(&binding_display(&kb.navigate_up), "Navigate up", &app.theme),
+        help_line_themed(&binding_display(&kb.navigate_down), "Navigate down", &app.theme),
+        help_line_themed(&binding_display(&kb.play), "Play selected station", &app.theme),
+        help_line_themed(&binding_display(&kb.stop), "Stop playback", &app.theme),
+        help_line_themed(&binding_display(&kb.volume_up), "Volume up", &app.theme),
+        help_line_themed(&binding_display(&kb.volume_down), "Volume down", &app.theme),
+        help_line_themed(&binding_display(&kb.search), "Search stations", &app.theme),
+        help_line_themed(&binding_display(&kb.toggle_favorite), "Toggle favorite", &app.theme),
+        help_line_themed(&binding_display(&kb.station_detail), "Station details", &app.theme),
+        help_line_themed(&binding_display(&kb.load_more), "Load more stations", &app.theme),
+        help_line_themed(&binding_display(&kb.cycle_panel), "Cycle panel", &app.theme),
+        help_line_themed(&binding_display(&kb.genre_next), "Next genre", &app.theme),
+        help_line_themed(&binding_display(&kb.genre_prev), "Previous genre", &app.theme),
+        help_line_themed(&binding_display(&kb.genre_picker), "Genre picker", &app.theme),
+        help_line_themed(&binding_display(&kb.help), "Toggle this help", &app.theme),
+        help_line_themed(&binding_display(&kb.perf_toggle), "Performance profiler", &app.theme),
+        help_line_themed(&binding_display(&kb.perf_tick_slower), "Tick rate slower (profiler)", &app.theme),
+        help_line_themed(&binding_display(&kb.perf_tick_faster), "Tick rate faster (profiler)", &app.theme),
+        help_line_themed(&binding_display(&kb.settings), "Keybinding settings", &app.theme),
+        help_line_themed(&binding_display(&kb.theme_picker), "Theme picker", &app.theme),
+        help_line_themed(&binding_display(&kb.quit), "Quit", &app.theme),
         Line::from(""),
         Line::from(Span::styled(
             "Press ? or Esc to close",
@@ -50,11 +51,11 @@ pub fn draw_help(f: &mut Frame, app: &App, area: Rect) {
     let block = Block::default()
         .title(Span::styled(
             " Help ",
-            Style::default().fg(YELLOW).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(YELLOW))
+        .border_style(Style::default().fg(app.theme.text_warn))
         .padding(Padding::new(2, 2, 1, 1))
         .style(Style::default().bg(Color::Rgb(10, 10, 20)));
 
@@ -79,12 +80,12 @@ pub fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
             )),
             Line::from(""),
-            info_line("Genre", &s.tags, MAGENTA),
-            info_line("Country", &s.country, CYAN),
-            info_line("Bitrate", &format!("{} kbps", s.bitrate), YELLOW),
-            info_line("Codec", &s.codec, ORANGE),
-            info_line("Votes", &s.votes.to_string(), NEON_GREEN),
-            info_line("Favorite", fav, YELLOW),
+            info_line("Genre", &s.tags, app.theme.secondary),
+            info_line("Country", &s.country, app.theme.accent),
+            info_line("Bitrate", &format!("{} kbps", s.bitrate), app.theme.text_warn),
+            info_line("Codec", &s.codec, app.theme.text_warm),
+            info_line("Votes", &s.votes.to_string(), app.theme.positive),
+            info_line("Favorite", fav, app.theme.text_warn),
             Line::from(""),
             info_line("URL", &s.url, Color::Rgb(100, 150, 255)),
             info_line("Homepage", &s.homepage, Color::Rgb(100, 150, 255)),
@@ -97,18 +98,18 @@ pub fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
     } else {
         vec![Line::from(Span::styled(
             "No station selected",
-            Style::default().fg(DIM_WHITE),
+            Style::default().fg(app.theme.text_muted),
         ))]
     };
 
     let block = Block::default()
         .title(Span::styled(
             " Station Details ",
-            Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(CYAN))
+        .border_style(Style::default().fg(app.theme.accent))
         .padding(Padding::new(2, 2, 1, 1))
         .style(Style::default().bg(Color::Rgb(10, 10, 20)));
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -1,6 +1,6 @@
 use crate::app::App;
 use crate::storage::config::keycode_to_string;
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -19,7 +19,7 @@ const COL_PRIMARY: usize = 8;
 
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let popup_w: u16 = 48;
-    let popup_h: u16 = 34;
+    let popup_h: u16 = 35;
     let x = area.x + area.width.saturating_sub(popup_w) / 2;
     let y = area.y + area.height.saturating_sub(popup_h) / 2;
     let popup = Rect::new(x, y, popup_w.min(area.width), popup_h.min(area.height));
@@ -30,7 +30,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     lines.push(Line::from(Span::styled(
         "⚙  Keybinding Settings",
-        Style::default().fg(CYAN).add_modifier(Modifier::BOLD),
+        Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::from(""));
 
@@ -38,15 +38,15 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(vec![
         Span::styled(
             format!("{:<width$}", "  Action", width = COL_ACTION),
-            Style::default().fg(YELLOW).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             format!("{:<width$}", "Primary", width = COL_PRIMARY),
-            Style::default().fg(YELLOW).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "Alt".to_string(),
-            Style::default().fg(YELLOW).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD),
         ),
     ]));
 
@@ -70,7 +70,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         };
 
         let indicator = if is_selected { "▸ " } else { "  " };
-        let label_color = if is_selected { Color::White } else { DIM_WHITE };
+        let label_color = if is_selected { Color::White } else { app.theme.text_muted };
 
         // Build the action cell: indicator + label, padded to COL_ACTION total
         let action_text = format!("{}{}", indicator, label);
@@ -80,15 +80,15 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         let alt_str = binding.alt.map_or("—".to_string(), keycode_to_string);
 
         let primary_style = if awaiting_slot == Some(false) {
-            Style::default().fg(RED).add_modifier(Modifier::SLOW_BLINK | Modifier::BOLD).bg(row_bg)
+            Style::default().fg(app.theme.text_error).add_modifier(Modifier::SLOW_BLINK | Modifier::BOLD).bg(row_bg)
         } else {
-            Style::default().fg(NEON_GREEN).bg(row_bg)
+            Style::default().fg(app.theme.positive).bg(row_bg)
         };
 
         let alt_style = if awaiting_slot == Some(true) {
-            Style::default().fg(RED).add_modifier(Modifier::SLOW_BLINK | Modifier::BOLD).bg(row_bg)
+            Style::default().fg(app.theme.text_error).add_modifier(Modifier::SLOW_BLINK | Modifier::BOLD).bg(row_bg)
         } else {
-            Style::default().fg(ORANGE).bg(row_bg)
+            Style::default().fg(app.theme.text_warm).bg(row_bg)
         };
 
         let primary_display = if awaiting_slot == Some(false) {
@@ -129,37 +129,37 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     if app.settings_awaiting_key.is_some() {
         lines.push(Line::from(Span::styled(
             "  Press any key to assign • Esc cancel",
-            Style::default().fg(RED).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.text_error).add_modifier(Modifier::BOLD),
         )));
     } else {
         lines.push(Line::from(vec![
-            Span::styled("  ↑/↓", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" nav ", Style::default().fg(DIM_WHITE)),
-            Span::styled("Enter", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" primary ", Style::default().fg(DIM_WHITE)),
-            Span::styled("a", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" alt ", Style::default().fg(DIM_WHITE)),
-            Span::styled("d", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" clear", Style::default().fg(DIM_WHITE)),
+            Span::styled("  ↑/↓", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+            Span::styled(" nav ", Style::default().fg(app.theme.text_muted)),
+            Span::styled("Enter", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+            Span::styled(" primary ", Style::default().fg(app.theme.text_muted)),
+            Span::styled("a", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+            Span::styled(" alt ", Style::default().fg(app.theme.text_muted)),
+            Span::styled("d", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+            Span::styled(" clear", Style::default().fg(app.theme.text_muted)),
         ]));
         lines.push(Line::from(vec![
-            Span::styled("  r", Style::default().fg(YELLOW).add_modifier(Modifier::BOLD)),
-            Span::styled(" reset ", Style::default().fg(DIM_WHITE)),
-            Span::styled("R", Style::default().fg(YELLOW).add_modifier(Modifier::BOLD)),
-            Span::styled(" reset all ", Style::default().fg(DIM_WHITE)),
-            Span::styled("Esc/S", Style::default().fg(NEON_GREEN).add_modifier(Modifier::BOLD)),
-            Span::styled(" close", Style::default().fg(DIM_WHITE)),
+            Span::styled("  r", Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD)),
+            Span::styled(" reset ", Style::default().fg(app.theme.text_muted)),
+            Span::styled("R", Style::default().fg(app.theme.text_warn).add_modifier(Modifier::BOLD)),
+            Span::styled(" reset all ", Style::default().fg(app.theme.text_muted)),
+            Span::styled("Esc/S", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+            Span::styled(" close", Style::default().fg(app.theme.text_muted)),
         ]));
     }
 
     let block = Block::default()
         .title(Span::styled(
             " Settings ",
-            Style::default().fg(MAGENTA).add_modifier(Modifier::BOLD),
+            Style::default().fg(app.theme.secondary).add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(MAGENTA))
+        .border_style(Style::default().fg(app.theme.secondary))
         .padding(Padding::new(1, 1, 1, 1))
         .style(Style::default().bg(Color::Rgb(10, 10, 20)));
 

--- a/src/ui/song_log.rs
+++ b/src/ui/song_log.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use super::helpers::*;
+use super::helpers::truncate_str;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -27,7 +27,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
         .padding(Padding::new(1, 1, 0, 0))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -57,7 +57,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
             let is_current = i == 0;
             let time_style = Style::default().fg(Color::Rgb(80, 80, 110));
             let title_style = if is_current {
-                Style::default().fg(YELLOW)
+                Style::default().fg(app.theme.text_warn)
             } else {
                 Style::default().fg(Color::Rgb(140, 140, 160))
             };
@@ -82,7 +82,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled(format!("{} ", entry.timestamp), time_style),
                 Span::styled(
                     indicator,
-                    Style::default().fg(if is_current { NEON_GREEN } else { Color::Rgb(40, 40, 60) }),
+                    Style::default().fg(if is_current { app.theme.positive } else { Color::Rgb(40, 40, 60) }),
                 ),
                 Span::styled(display_title, title_style),
                 Span::styled(

--- a/src/ui/station_list.rs
+++ b/src/ui/station_list.rs
@@ -1,5 +1,5 @@
 use crate::app::{ActivePanel, App};
-use super::helpers::*;
+use super::helpers::truncate_str;
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -28,11 +28,11 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                     let prefix = if playing_marker { "♪ " } else { "  " };
 
                     let line = Line::from(vec![
-                        Span::styled(fav_marker, Style::default().fg(YELLOW)),
-                        Span::styled(prefix, Style::default().fg(NEON_GREEN)),
+                        Span::styled(fav_marker, Style::default().fg(app.theme.text_warn)),
+                        Span::styled(prefix, Style::default().fg(app.theme.positive)),
                         Span::styled(
                             truncate_str(&s.name, name_budget),
-                            Style::default().fg(DIM_WHITE),
+                            Style::default().fg(app.theme.text_muted),
                         ),
                     ]);
                     ListItem::new(line)
@@ -64,11 +64,11 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                     let prefix = if playing { "♪ " } else { "  " };
 
                     let line = Line::from(vec![
-                        Span::styled("★ ", Style::default().fg(YELLOW)),
-                        Span::styled(prefix, Style::default().fg(NEON_GREEN)),
+                        Span::styled("★ ", Style::default().fg(app.theme.text_warn)),
+                        Span::styled(prefix, Style::default().fg(app.theme.positive)),
                         Span::styled(
                             truncate_str(&fav.name, name_budget),
-                            Style::default().fg(DIM_WHITE),
+                            Style::default().fg(app.theme.text_muted),
                         ),
                         Span::styled(
                             format!(" │ {}", truncate_str(&fav.genre, 15)),
@@ -95,7 +95,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                         Span::styled("  ", Style::default()),
                         Span::styled(
                             truncate_str(&h.name, name_budget),
-                            Style::default().fg(DIM_WHITE),
+                            Style::default().fg(app.theme.text_muted),
                         ),
                         Span::styled(
                             format!(" │ {}", time_str),
@@ -114,9 +114,9 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let border_color = match app.active_panel {
-        ActivePanel::Stations => CYAN,
-        ActivePanel::Favorites => YELLOW,
-        ActivePanel::History => MAGENTA,
+        ActivePanel::Stations => app.theme.accent,
+        ActivePanel::Favorites => app.theme.text_warn,
+        ActivePanel::History => app.theme.secondary,
     };
 
     let block = Block::default()
@@ -127,13 +127,13 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border_color))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let list = List::new(items)
         .block(block)
         .highlight_style(
             Style::default()
-                .bg(HIGHLIGHT_BG)
+                .bg(app.theme.bg_highlight)
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
         )

--- a/src/ui/stream_info.rs
+++ b/src/ui/stream_info.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
@@ -20,7 +20,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
         .padding(Padding::new(1, 1, 0, 0))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -32,7 +32,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
     // Volume is always shown
-    lines.push(volume_compact(app.volume));
+    lines.push(volume_compact(app.volume, &app.theme));
 
     if !app.player.is_playing() {
         // Only show as many lines as we have room
@@ -45,7 +45,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
     // Connection uptime
     let uptime = si.uptime_str();
-    lines.push(compact_line("Uptime", &uptime, NEON_GREEN));
+    lines.push(compact_line("Uptime", &uptime, app.theme.positive));
 
     // Audio bitrate (actual from mpv vs advertised)
     if si.audio_bitrate > 0.0 {
@@ -66,14 +66,14 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         let color = if advertised > 0 {
             let ratio = actual_kbps / advertised as f64;
             if ratio > 0.85 {
-                NEON_GREEN
+                app.theme.positive
             } else if ratio > 0.5 {
-                YELLOW
+                app.theme.text_warn
             } else {
-                RED
+                app.theme.text_error
             }
         } else {
-            CYAN
+            app.theme.accent
         };
         lines.push(compact_line("Bitrate", &bitrate_str, color));
     } else {
@@ -102,17 +102,17 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     } else {
         "—".to_string()
     };
-    lines.push(compact_line("Format", &audio_fmt, CYAN));
+    lines.push(compact_line("Format", &audio_fmt, app.theme.accent));
 
     // Buffer health
     if si.cache_duration > 0.0 {
         let buf_str = format!("{:.1}s", si.cache_duration);
         let color = if si.cache_duration > 5.0 {
-            NEON_GREEN
+            app.theme.positive
         } else if si.cache_duration > 2.0 {
-            YELLOW
+            app.theme.text_warn
         } else {
-            RED
+            app.theme.text_error
         };
 
         // Simple visual bar for buffer
@@ -138,15 +138,15 @@ fn compact_line(label: &str, value: &str, color: Color) -> Line<'static> {
     ])
 }
 
-fn volume_compact(volume: u32) -> Line<'static> {
+fn volume_compact(volume: u32, theme: &crate::ui::themes::Theme) -> Line<'static> {
     let filled = (volume as usize * 10) / 100;
     let empty = 10 - filled;
     let bar_color = if volume > 80 {
-        RED
+        theme.text_error
     } else if volume > 50 {
-        YELLOW
+        theme.text_warn
     } else {
-        NEON_GREEN
+        theme.positive
     };
 
     Line::from(vec![

--- a/src/ui/theme_picker.rs
+++ b/src/ui/theme_picker.rs
@@ -1,0 +1,91 @@
+use crate::app::App;
+use crate::ui::themes::Theme;
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Clear, Padding, Paragraph},
+    Frame,
+    layout::Rect,
+};
+
+pub fn draw(f: &mut Frame, app: &App, area: Rect) {
+    let themes = Theme::all();
+    let total = themes.len();
+
+    let popup_w: u16 = 40_u16.min(area.width);
+    let popup_h: u16 = (total as u16 + 8).min(area.height);
+    let x = area.x + area.width.saturating_sub(popup_w) / 2;
+    let y = area.y + area.height.saturating_sub(popup_h) / 2;
+    let popup = Rect::new(x, y, popup_w, popup_h);
+    f.render_widget(Clear, popup);
+
+    let mut lines = Vec::new();
+
+    lines.push(Line::from(Span::styled(
+        "🎨  Select Theme",
+        Style::default().fg(app.theme.accent).add_modifier(Modifier::BOLD),
+    )));
+    lines.push(Line::from(""));
+
+    for (i, theme) in themes.iter().enumerate() {
+        let is_selected = i == app.theme_selected;
+        let is_active = theme.name == app.theme.name;
+
+        let (indicator, bg) = if is_selected {
+            ("▸ ", Color::Rgb(40, 40, 70))
+        } else {
+            ("  ", Color::Reset)
+        };
+
+        let suffix = if is_active { " ●" } else { "" };
+
+        let name_color = if is_active {
+            app.theme.positive
+        } else if is_selected {
+            Color::White
+        } else {
+            Color::Rgb(160, 160, 180)
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(indicator, Style::default().fg(name_color).bg(bg)),
+            // Color swatches showing the theme's accent, secondary, positive
+            Span::styled("██", Style::default().fg(theme.accent).bg(bg)),
+            Span::styled("██", Style::default().fg(theme.secondary).bg(bg)),
+            Span::styled("██", Style::default().fg(theme.positive).bg(bg)),
+            Span::styled(" ", Style::default().bg(bg)),
+            Span::styled(
+                format!("{}{}", theme.name, suffix),
+                Style::default().fg(name_color).bg(bg),
+            ),
+        ]));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        format!("{:─<width$}", "", width = 34),
+        Style::default().fg(Color::Rgb(50, 50, 70)),
+    )));
+    lines.push(Line::from(vec![
+        Span::styled("  ↑/↓", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" nav  ", Style::default().fg(app.theme.text_muted)),
+        Span::styled("Enter", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" apply  ", Style::default().fg(app.theme.text_muted)),
+        Span::styled("Esc", Style::default().fg(app.theme.positive).add_modifier(Modifier::BOLD)),
+        Span::styled(" close", Style::default().fg(app.theme.text_muted)),
+    ]));
+
+    let block = Block::default()
+        .title(Span::styled(
+            " Theme ",
+            Style::default().fg(app.theme.secondary).add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(app.theme.secondary))
+        .padding(Padding::new(1, 1, 1, 1))
+        .style(Style::default().bg(Color::Rgb(10, 10, 20)));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    f.render_widget(paragraph, popup);
+}

--- a/src/ui/themes.rs
+++ b/src/ui/themes.rs
@@ -1,0 +1,204 @@
+use ratatui::style::Color;
+
+/// A complete color theme for the player UI.
+/// Does not affect the launcher, main menu, exit animation, or profiler overlay.
+#[derive(Clone)]
+pub struct Theme {
+    pub name: &'static str,
+
+    // ── Primary accents ──
+    /// Primary accent: borders, active indicators, titles (default: cyan)
+    pub accent: Color,
+    /// Secondary accent: overlays, genre picker border (default: magenta)
+    pub secondary: Color,
+    /// Positive/active: selected items, playing status, good values (default: neon green)
+    pub positive: Color,
+
+    // ── Text ──
+    /// Standard muted text: labels, secondary info (default: dim white)
+    pub text_muted: Color,
+    /// Warning/highlight text: bitrate, genre tags (default: yellow)
+    pub text_warn: Color,
+    /// Alert/error text: errors, high values (default: red)
+    pub text_error: Color,
+    /// Warm accent: country, secondary highlights (default: orange)
+    pub text_warm: Color,
+
+    // ── Backgrounds ──
+    /// Main dark background (default: deep navy)
+    pub bg_dark: Color,
+    /// Panel background (default: slightly lighter navy)
+    pub bg_panel: Color,
+    /// Highlighted/selected row background (default: muted indigo)
+    pub bg_highlight: Color,
+
+    // ── Visualizer ──
+    /// Peak indicator color on spectrum bars (default: white)
+    pub peak: Color,
+}
+
+impl Theme {
+    pub fn all() -> Vec<Theme> {
+        vec![
+            Self::crt(),
+            Self::gruvbox(),
+            Self::nord(),
+            Self::dracula(),
+            Self::monokai(),
+            Self::catppuccin(),
+            Self::hacker(),
+            Self::solarized(),
+        ]
+    }
+
+    pub fn by_name(name: &str) -> Theme {
+        Self::all()
+            .into_iter()
+            .find(|t| t.name.eq_ignore_ascii_case(name))
+            .unwrap_or_else(Self::crt)
+    }
+
+    /// Default CRT phosphor theme — the original AetherTune aesthetic
+    pub fn crt() -> Theme {
+        Theme {
+            name: "CRT",
+            accent: Color::Rgb(0, 255, 255),       // cyan
+            secondary: Color::Rgb(200, 80, 255),    // magenta
+            positive: Color::Rgb(57, 255, 20),      // neon green
+            text_muted: Color::Rgb(160, 160, 180),  // dim white
+            text_warn: Color::Rgb(255, 215, 0),     // yellow
+            text_error: Color::Rgb(255, 60, 60),    // red
+            text_warm: Color::Rgb(255, 140, 0),     // orange
+            bg_dark: Color::Rgb(15, 15, 25),
+            bg_panel: Color::Rgb(20, 20, 35),
+            bg_highlight: Color::Rgb(40, 40, 80),
+            peak: Color::Rgb(255, 255, 255),
+        }
+    }
+
+    /// Gruvbox — warm retro palette
+    pub fn gruvbox() -> Theme {
+        Theme {
+            name: "Gruvbox",
+            accent: Color::Rgb(131, 165, 152),      // aqua
+            secondary: Color::Rgb(211, 134, 155),    // purple
+            positive: Color::Rgb(184, 187, 38),      // green
+            text_muted: Color::Rgb(168, 153, 132),   // gray
+            text_warn: Color::Rgb(250, 189, 47),     // yellow
+            text_error: Color::Rgb(251, 73, 52),     // red
+            text_warm: Color::Rgb(254, 128, 25),     // orange
+            bg_dark: Color::Rgb(40, 40, 40),
+            bg_panel: Color::Rgb(50, 48, 47),
+            bg_highlight: Color::Rgb(80, 73, 69),
+            peak: Color::Rgb(235, 219, 178),         // fg
+        }
+    }
+
+    /// Nord — cool arctic palette
+    pub fn nord() -> Theme {
+        Theme {
+            name: "Nord",
+            accent: Color::Rgb(136, 192, 208),       // frost blue
+            secondary: Color::Rgb(180, 142, 173),     // purple
+            positive: Color::Rgb(163, 190, 140),       // green
+            text_muted: Color::Rgb(127, 140, 141),     // muted
+            text_warn: Color::Rgb(235, 203, 139),       // yellow
+            text_error: Color::Rgb(191, 97, 106),       // red
+            text_warm: Color::Rgb(208, 135, 112),       // orange
+            bg_dark: Color::Rgb(46, 52, 64),
+            bg_panel: Color::Rgb(59, 66, 82),
+            bg_highlight: Color::Rgb(76, 86, 106),
+            peak: Color::Rgb(229, 233, 240),
+        }
+    }
+
+    /// Dracula — dark purple theme
+    pub fn dracula() -> Theme {
+        Theme {
+            name: "Dracula",
+            accent: Color::Rgb(139, 233, 253),       // cyan
+            secondary: Color::Rgb(255, 121, 198),     // pink
+            positive: Color::Rgb(80, 250, 123),        // green
+            text_muted: Color::Rgb(98, 114, 164),      // comment
+            text_warn: Color::Rgb(241, 250, 140),       // yellow
+            text_error: Color::Rgb(255, 85, 85),        // red
+            text_warm: Color::Rgb(255, 184, 108),        // orange
+            bg_dark: Color::Rgb(40, 42, 54),
+            bg_panel: Color::Rgb(48, 50, 65),
+            bg_highlight: Color::Rgb(68, 71, 90),
+            peak: Color::Rgb(248, 248, 242),
+        }
+    }
+
+    /// Monokai — classic editor theme
+    pub fn monokai() -> Theme {
+        Theme {
+            name: "Monokai",
+            accent: Color::Rgb(102, 217, 239),        // blue
+            secondary: Color::Rgb(174, 129, 255),      // purple
+            positive: Color::Rgb(166, 226, 46),         // green
+            text_muted: Color::Rgb(117, 113, 94),       // comment
+            text_warn: Color::Rgb(230, 219, 116),        // yellow
+            text_error: Color::Rgb(249, 38, 114),        // red/pink
+            text_warm: Color::Rgb(253, 151, 31),          // orange
+            bg_dark: Color::Rgb(39, 40, 34),
+            bg_panel: Color::Rgb(49, 50, 44),
+            bg_highlight: Color::Rgb(73, 72, 62),
+            peak: Color::Rgb(248, 248, 242),
+        }
+    }
+
+    /// Catppuccin Mocha — pastel dark theme
+    pub fn catppuccin() -> Theme {
+        Theme {
+            name: "Catppuccin",
+            accent: Color::Rgb(137, 180, 250),         // blue
+            secondary: Color::Rgb(203, 166, 247),       // mauve
+            positive: Color::Rgb(166, 227, 161),         // green
+            text_muted: Color::Rgb(147, 153, 178),       // subtext
+            text_warn: Color::Rgb(249, 226, 175),         // yellow
+            text_error: Color::Rgb(243, 139, 168),         // red
+            text_warm: Color::Rgb(250, 179, 135),           // peach
+            bg_dark: Color::Rgb(30, 30, 46),
+            bg_panel: Color::Rgb(36, 36, 54),
+            bg_highlight: Color::Rgb(49, 50, 68),
+            peak: Color::Rgb(205, 214, 244),
+        }
+    }
+
+    /// Hacker — green on black terminal aesthetic
+    pub fn hacker() -> Theme {
+        Theme {
+            name: "Hacker",
+            accent: Color::Rgb(0, 255, 65),             // matrix green
+            secondary: Color::Rgb(0, 200, 50),           // darker green
+            positive: Color::Rgb(50, 255, 100),           // bright green
+            text_muted: Color::Rgb(0, 140, 40),           // dim green
+            text_warn: Color::Rgb(200, 255, 0),            // yellow-green
+            text_error: Color::Rgb(255, 50, 50),            // red (only non-green)
+            text_warm: Color::Rgb(100, 255, 50),            // lime
+            bg_dark: Color::Rgb(0, 5, 0),
+            bg_panel: Color::Rgb(0, 10, 0),
+            bg_highlight: Color::Rgb(0, 30, 5),
+            peak: Color::Rgb(150, 255, 150),
+        }
+    }
+
+    /// Solarized Dark — precision colors for readability
+    pub fn solarized() -> Theme {
+        Theme {
+            name: "Solarized",
+            accent: Color::Rgb(38, 139, 210),           // blue
+            secondary: Color::Rgb(108, 113, 196),        // violet
+            positive: Color::Rgb(133, 153, 0),            // green
+            text_muted: Color::Rgb(88, 110, 117),         // base01
+            text_warn: Color::Rgb(181, 137, 0),            // yellow
+            text_error: Color::Rgb(220, 50, 47),            // red
+            text_warm: Color::Rgb(203, 75, 22),              // orange
+            bg_dark: Color::Rgb(0, 43, 54),
+            bg_panel: Color::Rgb(7, 54, 66),
+            bg_highlight: Color::Rgb(28, 78, 93),
+            peak: Color::Rgb(238, 232, 213),
+        }
+    }
+}

--- a/src/ui/visualizer.rs
+++ b/src/ui/visualizer.rs
@@ -1,5 +1,5 @@
 use crate::app::App;
-use super::helpers::*;
+
 use ratatui::{
     style::{Color, Style},
     widgets::{Block, BorderType, Borders},
@@ -12,7 +12,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Rgb(60, 60, 100)))
-        .style(Style::default().bg(PANEL_BG));
+        .style(Style::default().bg(app.theme.bg_panel));
 
     let inner = block.inner(area);
     f.render_widget(block, area);
@@ -47,7 +47,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 let buf = f.buffer_mut();
                 buf.get_mut(x, y)
                     .set_char('─')
-                    .set_fg(PEAK_COLOR);
+                    .set_fg(app.theme.peak);
             } else if row < bar_h && bar_h > 0 {
                 let frac = row as f32 / bar_h as f32;
                 let color = if frac < 0.5 {


### PR DESCRIPTION
- New Theme struct with 11 semantic color roles (accent, secondary, positive, text_muted, text_warn, text_error, text_warm, bg_dark, bg_panel, bg_highlight, peak)
- 8 built-in themes: CRT (default), Gruvbox, Nord, Dracula, Monokai, Catppuccin, Hacker, Solarized
- Theme picker overlay (t key) with color swatch previews and live preview on navigate. Theme changes as you arrow through the list
- Theme persisted to config.json, restored on launch
- Theme picker is a configurable keybinding (default: t)
- All player UI files use theme colors instead of hardcoded constants
- Launcher, exit animation, and profiler overlay are unaffected
- Settings overlay height bumped for new keybinding row
- README updated with Themes section, keybinding table, project structure
- Closes #25