### PR TITLE
feat: toggle visualizer with automatic low-power mode (v0.7.7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "crossterm",
  "libc",

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Below is a list of default keyboard shortcuts. All keybindings can be remapped f
 | `Shift+Tab`            | Cycle genre category (backward)              |
 | `g`                    | Genre picker overlay                         |
 | `t`                    | Theme picker overlay                         |
+| `v`                    | Toggle visualizer on/off                     |
 | `?`                    | Help overlay                                 |
 | `S`                    | Customize keybindings                        |
 | `` ` ``                | Performance profiler                         |

--- a/src/app.rs
+++ b/src/app.rs
@@ -431,6 +431,8 @@ pub struct App {
     pub theme: crate::ui::themes::Theme,
     /// Currently selected index in the theme picker overlay
     pub theme_selected: usize,
+    /// Whether the visualizer is enabled (can be toggled at runtime)
+    pub visualizer_enabled: bool,
 }
 
 #[derive(Clone)]
@@ -478,10 +480,13 @@ impl App {
         let has_more = stations.len() as u32 >= 30;
         let analysis = audio_pipe::new_shared_analysis();
         let config = Config::load();
+        let mut player = Player::new(analysis.clone());
+        player.visualizer_enabled = config.visualizer_enabled;
+
         Self {
             stations,
             selected_index: 0,
-            player: Player::new(analysis.clone()),
+            player,
             volume: config.volume,
             search_query: String::new(),
             input_mode: InputMode::Normal,
@@ -531,6 +536,7 @@ impl App {
                 let all = crate::ui::themes::Theme::all();
                 all.iter().position(|t| t.name.eq_ignore_ascii_case(&config.theme)).unwrap_or(0)
             },
+            visualizer_enabled: config.visualizer_enabled,
         }
     }
 
@@ -719,10 +725,15 @@ impl App {
     /// Persist current tick rate, volume, and keybindings to config file
     pub fn save_config(&self) {
         let mut config = Config::load();
-        config.tick_rate_ms = self.tick_rate_ms;
+        // Only save tick_rate_ms when visualizer is enabled — otherwise we'd
+        // overwrite the user's preference with the low-power 200ms value
+        if self.visualizer_enabled {
+            config.tick_rate_ms = self.tick_rate_ms;
+        }
         config.volume = self.volume;
         config.keybindings = self.keybindings.clone();
         config.theme = self.theme.name.to_string();
+        config.visualizer_enabled = self.visualizer_enabled;
         config.save();
     }
 

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -90,6 +90,8 @@ pub struct Player {
     has_parec: bool,
     /// Real-time stream information from mpv
     pub stream_info: StreamInfo,
+    /// Whether the visualizer is enabled (controls capture startup)
+    pub visualizer_enabled: bool,
 }
 
 impl Player {
@@ -123,6 +125,7 @@ impl Player {
             #[cfg(unix)]
             has_parec,
             stream_info: StreamInfo::new(),
+            visualizer_enabled: true,
         }
     }
 
@@ -164,9 +167,9 @@ impl Player {
                     std::thread::sleep(std::time::Duration::from_millis(400));
                     self.connect_ipc();
 
-                    // Start audio capture for visualization if parec is available
+                    // Start audio capture for visualization if parec is available and visualizer is on
                     #[cfg(unix)]
-                    if self.has_parec {
+                    if self.has_parec && self.visualizer_enabled {
                         self.start_capture();
                     }
                 }
@@ -257,6 +260,26 @@ impl Player {
     #[cfg(windows)]
     fn stop_capture(&mut self) {
         // No capture on Windows yet
+    }
+
+    /// Stop audio capture if it's currently running (called when visualizer is disabled)
+    pub fn stop_capture_if_running(&mut self) {
+        #[cfg(unix)]
+        {
+            if self.capture.is_some() {
+                self.stop_capture();
+            }
+        }
+    }
+
+    /// Restart audio capture (called when visualizer is re-enabled while playing)
+    pub fn restart_capture(&mut self) {
+        #[cfg(unix)]
+        {
+            if self.has_parec && self.capture.is_none() && self.process.is_some() {
+                self.start_capture();
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Construct the app immediately with an empty station list.
     // The initial fetch runs in the background — stations appear once it completes.
     let mut app = app::App::new(Vec::new());
+    // If visualizer is disabled, start in low-power mode
+    if !app.visualizer_enabled {
+        app.tick_rate_ms = 200;
+    }
     app.start_initial_fetch();
 
     let mut last_tick = Instant::now();
@@ -289,6 +293,22 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 .position(|t| t.name == app.theme.name)
                                 .unwrap_or(0);
                             app.overlay = Overlay::ThemePicker;
+                        } else if app.keybindings.visualizer_toggle.matches(kc) {
+                            app.visualizer_enabled = !app.visualizer_enabled;
+                            app.player.visualizer_enabled = app.visualizer_enabled;
+                            if !app.visualizer_enabled {
+                                // Stop audio capture and drop to low-power tick rate
+                                app.player.stop_capture_if_running();
+                                app.tick_rate_ms = 200; // 5 FPS — plenty for static UI
+                            } else {
+                                // Restore user's configured tick rate from config
+                                let config = crate::storage::config::Config::load();
+                                app.tick_rate_ms = config.tick_rate_ms;
+                                if app.player.is_playing() {
+                                    app.player.restart_capture();
+                                }
+                            }
+                            app.save_config();
                         } else if app.keybindings.search.matches(kc) {
                             app.search_query.clear();
                             app.input_mode = InputMode::Editing;
@@ -387,14 +407,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             poll_us = poll_start.elapsed().as_micros() as u64;
 
             let vis_start = Instant::now();
-            if app.player.has_real_audio() {
-                let used_real = app.visualizer.tick_real(&app.analysis, app.volume);
-                if !used_real {
-                    app.visualizer.tick_simulated(app.player.is_playing(), app.player.audio_level, app.volume);
+            if app.visualizer_enabled {
+                if app.player.has_real_audio() {
+                    let used_real = app.visualizer.tick_real(&app.analysis, app.volume);
+                    if !used_real {
+                        app.visualizer.tick_simulated(app.player.is_playing(), app.player.audio_level, app.volume);
+                    }
+                } else {
+                    let level = app.player.audio_level;
+                    app.visualizer.tick_simulated(app.player.is_playing(), level, app.volume);
                 }
-            } else {
-                let level = app.player.audio_level;
-                app.visualizer.tick_simulated(app.player.is_playing(), level, app.volume);
             }
             vis_us = vis_start.elapsed().as_micros() as u64;
 

--- a/src/storage/config.rs
+++ b/src/storage/config.rs
@@ -46,6 +46,7 @@ pub struct KeyBindings {
     pub genre_prev: KeyBinding,
     pub genre_picker: KeyBinding,
     pub theme_picker: KeyBinding,
+    pub visualizer_toggle: KeyBinding,
     pub help: KeyBinding,
     pub perf_toggle: KeyBinding,
     pub perf_tick_slower: KeyBinding,
@@ -73,6 +74,7 @@ impl KeyBindings {
             ("genre_prev",       "Previous Genre",      &self.genre_prev),
             ("genre_picker",     "Genre Picker",        &self.genre_picker),
             ("theme_picker",     "Theme Picker",        &self.theme_picker),
+            ("visualizer_toggle","Toggle Visualizer",   &self.visualizer_toggle),
             ("help",             "Help Overlay",        &self.help),
             ("perf_toggle",      "Perf Profiler",       &self.perf_toggle),
             ("perf_tick_slower",  "Tick Rate Slower",   &self.perf_tick_slower),
@@ -100,6 +102,7 @@ impl KeyBindings {
             "genre_prev"       => &mut self.genre_prev,
             "genre_picker"     => &mut self.genre_picker,
             "theme_picker"     => &mut self.theme_picker,
+            "visualizer_toggle" => &mut self.visualizer_toggle,
             "help"             => &mut self.help,
             "perf_toggle"      => &mut self.perf_toggle,
             "perf_tick_slower"  => &mut self.perf_tick_slower,
@@ -136,6 +139,7 @@ impl Default for KeyBindings {
             genre_prev:       KeyBinding::new(KeyCode::Char('[')),
             genre_picker:     KeyBinding::new(KeyCode::Char('g')),
             theme_picker:     KeyBinding::new(KeyCode::Char('t')),
+            visualizer_toggle: KeyBinding::new(KeyCode::Char('v')),
             help:             KeyBinding::new(KeyCode::Char('?')),
             perf_toggle:      KeyBinding::new(KeyCode::Char('`')),
             perf_tick_slower:  KeyBinding::with_alt(KeyCode::Char('<'), KeyCode::Char(',')),
@@ -217,6 +221,8 @@ pub struct Config {
     pub keybindings: KeyBindings,
     /// Theme name (e.g. "CRT", "Gruvbox", "Nord")
     pub theme: String,
+    /// Whether the visualizer is enabled (default: true)
+    pub visualizer_enabled: bool,
     path: PathBuf,
 }
 
@@ -247,7 +253,9 @@ impl Config {
                 let keybindings = Self::load_keybindings(&contents);
                 let theme = Self::extract_string(&contents, "theme")
                     .unwrap_or_else(|| "CRT".to_string());
-                return Self { tick_rate_ms, volume, country_code, keybindings, theme, path };
+                let visualizer_enabled = Self::extract_bool(&contents, "visualizer_enabled")
+                    .unwrap_or(true);
+                return Self { tick_rate_ms, volume, country_code, keybindings, theme, visualizer_enabled, path };
             }
         }
         Self {
@@ -256,6 +264,7 @@ impl Config {
             country_code: String::new(),
             keybindings: KeyBindings::default(),
             theme: "CRT".to_string(),
+            visualizer_enabled: true,
             path,
         }
     }
@@ -306,8 +315,8 @@ impl Config {
         let theme_escaped = self.theme.replace('\\', "\\\\").replace('"', "\\\"");
 
         let json = format!(
-            "{{\n  \"tick_rate_ms\": {},\n  \"volume\": {},\n  \"country_code\": \"{}\",\n  \"theme\": \"{}\",\n    \"keybindings\": {}\n}}",
-            self.tick_rate_ms, self.volume, cc_escaped, theme_escaped, kb_json
+            "{{\n  \"tick_rate_ms\": {},\n  \"volume\": {},\n  \"country_code\": \"{}\",\n  \"theme\": \"{}\",\n  \"visualizer_enabled\": {},\n    \"keybindings\": {}\n}}",
+            self.tick_rate_ms, self.volume, cc_escaped, theme_escaped, self.visualizer_enabled, kb_json
         );
         let _ = fs::write(&self.path, json);
     }
@@ -425,6 +434,19 @@ impl Config {
             }
         }
         None
+    }
+
+    fn extract_bool(json: &str, key: &str) -> Option<bool> {
+        let pattern = format!("\"{}\":", key);
+        let idx = json.find(&pattern)?;
+        let after = json[idx + pattern.len()..].trim_start();
+        if after.starts_with("true") {
+            Some(true)
+        } else if after.starts_with("false") {
+            Some(false)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -52,6 +52,13 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
         let help_key = keycode_to_string(app.keybindings.help.primary);
         let settings_key = keycode_to_string(app.keybindings.settings.primary);
 
+        let vis_key = keycode_to_string(app.keybindings.visualizer_toggle.primary);
+        let vis_status = if app.visualizer_enabled {
+            String::new()
+        } else {
+            format!("  │  vis: off ({})", vis_key)
+        };
+
         let line = Line::from(vec![
             Span::styled(" ", Style::default()),
             playing_indicator,
@@ -60,8 +67,12 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(app.theme.accent),
             ),
             Span::styled(
-                format!("  │  {} search  │  {} genre  │  {} theme  │  {} help  │  {} settings", search_key, genre_key, theme_key, help_key, settings_key),
+                format!("  │  {} search  │  {} genre  │  {} theme  │  {} help  │  {} settings  │  {} vizualizer toggle", search_key, genre_key, theme_key, help_key, settings_key, vis_key),
                 Style::default().fg(Color::Rgb(80, 80, 110)),
+            ),
+            Span::styled(
+                vis_status.clone(),
+                Style::default().fg(app.theme.text_warn),
             ),
         ]);
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -84,27 +84,41 @@ fn draw_body(f: &mut Frame, app: &App, area: Rect) {
     now_playing::draw(f, app, right_chunks[0]);
 
     // Middle row: song log on left, visualizer + stream info stacked on right
-    let middle_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(60), // Song log
-            Constraint::Percentage(40), // Visualizer + stream info column
-        ])
-        .split(right_chunks[1]);
+    if app.visualizer_enabled {
+        let middle_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(60), // Song log
+                Constraint::Percentage(40), // Visualizer + stream info column
+            ])
+            .split(right_chunks[1]);
 
-    song_log::draw(f, app, middle_chunks[0]);
+        song_log::draw(f, app, middle_chunks[0]);
 
-    // Right column: visualizer on top, stream info below
-    let vis_column = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage(50), // Visualizer
-            Constraint::Percentage(50), // Stream info
-        ])
-        .split(middle_chunks[1]);
+        // Right column: visualizer on top, stream info below
+        let vis_column = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Percentage(50), // Visualizer
+                Constraint::Percentage(50), // Stream info
+            ])
+            .split(middle_chunks[1]);
 
-    visualizer::draw(f, app, vis_column[0]);
-    stream_info::draw(f, app, vis_column[1]);
+        visualizer::draw(f, app, vis_column[0]);
+        stream_info::draw(f, app, vis_column[1]);
+    } else {
+        // Visualizer disabled — song log gets full width, stream info below
+        let middle_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(70), // Song log (wider)
+                Constraint::Percentage(30), // Stream info only
+            ])
+            .split(right_chunks[1]);
+
+        song_log::draw(f, app, middle_chunks[0]);
+        stream_info::draw(f, app, middle_chunks[1]);
+    }
 
     // Bottom: media browser
     media_browser::draw(f, app, right_chunks[2]);

--- a/src/ui/overlays.rs
+++ b/src/ui/overlays.rs
@@ -40,6 +40,7 @@ pub fn draw_help(f: &mut Frame, app: &App, area: Rect) {
         help_line_themed(&binding_display(&kb.perf_tick_faster), "Tick rate faster (profiler)", &app.theme),
         help_line_themed(&binding_display(&kb.settings), "Keybinding settings", &app.theme),
         help_line_themed(&binding_display(&kb.theme_picker), "Theme picker", &app.theme),
+        help_line_themed(&binding_display(&kb.visualizer_toggle), "Toggle visualizer", &app.theme),
         help_line_themed(&binding_display(&kb.quit), "Quit", &app.theme),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -19,7 +19,7 @@ const COL_PRIMARY: usize = 8;
 
 pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     let popup_w: u16 = 48;
-    let popup_h: u16 = 35;
+    let popup_h: u16 = 36;
     let x = area.x + area.width.saturating_sub(popup_w) / 2;
     let y = area.y + area.height.saturating_sub(popup_h) / 2;
     let popup = Rect::new(x, y, popup_w.min(area.width), popup_h.min(area.height));


### PR DESCRIPTION
- Press `v` to toggle visualizer on/off (persisted to config)
- When disabled: `parec` capture stops, tick rate drops to 200ms (~5 FPS), CPU load drops from ~56% to ~2%
- When re-enabled: tick rate restores from config, capture restarts
- Layout adapts: song log gets more width, stream info fills the visualizer's space
- Visualizer toggle is a configurable keybinding (default: v), shown in header, help overlay, and settings
- Header shows "vis: off (v)" indicator when disabled
- `save_config` skips tick_rate_ms when visualizer is off to preserve the user's real preference
- App starts in low-power mode if config has visualizer disabled
- Settings overlay height bumped for new keybinding row
- Closes #27