### PR TITLE
Allow favoriting stations from the history tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.7.8"
+version = "0.8.2"
 dependencies = [
  "crossterm",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "AetherTune"
-version = "0.8.0"
+version = "0.8.2"
 edition = "2024"
 
 [dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -761,6 +761,21 @@ impl App {
                 }
                 self.status_message = Some(format!("Removed '{}' from favorites", fav.name));
             }
+        } else if self.active_panel == ActivePanel::History {
+            if let Some(entry) = self.history.entries.get(self.hist_selected_index).cloned() {
+                let was_added = self.favorites.toggle(
+                    &entry.name,
+                    &entry.url,
+                    &entry.genre,
+                    &entry.country,
+                    entry.bitrate,
+                );
+                if was_added {
+                    self.status_message = Some(format!("★ Added '{}' to favorites", entry.name));
+                } else {
+                    self.status_message = Some(format!("Removed '{}' from favorites", entry.name));
+                }
+            }
         }
     }
 

--- a/src/ui/station_list.rs
+++ b/src/ui/station_list.rs
@@ -90,9 +90,10 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 .entries
                 .iter()
                 .map(|h| {
+                    let fav_marker = if app.is_favorite(&h.url) { "★ " } else { "  " };
                     let time_str = &h.played_at;
                     let line = Line::from(vec![
-                        Span::styled("  ", Style::default()),
+                        Span::styled(fav_marker, Style::default().fg(app.theme.text_warn)),
                         Span::styled(
                             truncate_str(&h.name, name_budget),
                             Style::default().fg(app.theme.text_muted),


### PR DESCRIPTION
- Add ActivePanel::History branch to toggle_favorite() in app.rs
- Show ★ indicator on favorited stations in the history list

History Tab shows Stars as well allows you to favorite/unfavorite:
<img width="1782" height="1509" alt="image" src="https://github.com/user-attachments/assets/a05afd15-b97d-49cf-a0c6-5114a8e3cb38" />


Closes #32