### PR TITLE
Make visualizer scale to panel size across resolutions

### DIFF
--- a/src/ui/visualizer.rs
+++ b/src/ui/visualizer.rs
@@ -22,34 +22,52 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     }
 
     let vis = &app.visualizer;
-    let num_bars = vis.num_bars().min(inner.width as usize / 2);
-    let max_h = vis.max_height().min(inner.height);
+    let num_bars = vis.num_bars().min(inner.width as usize);
+    let logical_max = vis.max_height(); // The 0..12 range from the visualizer logic
+    let display_h = inner.height;       // Actual rows available in the panel
 
-    let x_offset = inner.x + (inner.width.saturating_sub(num_bars as u16 * 2)) / 2;
+    if num_bars == 0 || display_h == 0 {
+        return;
+    }
+
+    // ── Horizontal sizing ──
+    // Divide the panel evenly among bars. Gap is 1 column when bars are
+    // narrow (≤3 cols), but grows proportionally so the ratio of bar-to-gap
+    // stays roughly the same on both 1080p and 4K.
+    let min_stride = (inner.width / num_bars as u16).max(2);
+    let gap = (min_stride / 4).max(1).min(min_stride - 1);
+    let bar_w = min_stride - gap;
+    let stride = bar_w + gap;
+    let total_used = stride * num_bars as u16 - gap;
+    let x_offset = inner.x + (inner.width.saturating_sub(total_used)) / 2;
 
     for i in 0..num_bars {
-        let bar_h = vis.bars[i].min(max_h);
-        let peak_h = vis.peaks[i].min(max_h);
+        // Scale logical bar/peak heights (0..logical_max) to display rows (0..display_h)
+        let bar_rows = (vis.bars[i] as u32 * display_h as u32 / logical_max as u32) as u16;
+        let peak_row = (vis.peaks[i] as u32 * display_h as u32 / logical_max as u32) as u16;
+        let bar_rows = bar_rows.min(display_h);
+        let peak_row = peak_row.min(display_h);
+        let bar_x = x_offset + (i as u16) * stride;
 
-        for row in 0..max_h {
-            let y = inner.y + (max_h - 1 - row);
-            let x = x_offset + (i as u16) * 2;
+        for row in 0..display_h {
+            let y = inner.y + (display_h - 1 - row);
 
-            if x >= inner.x + inner.width {
-                break;
-            }
-
-            if y >= inner.y + inner.height {
-                continue;
-            }
-
-            if row == peak_h && peak_h > bar_h {
+            if row == peak_row && peak_row > bar_rows {
                 let buf = f.buffer_mut();
-                buf.get_mut(x, y)
-                    .set_char('─')
-                    .set_fg(app.theme.peak);
-            } else if row < bar_h && bar_h > 0 {
-                let frac = row as f32 / bar_h as f32;
+                for col in 0..bar_w {
+                    let x = bar_x + col;
+                    if x >= inner.x + inner.width {
+                        break;
+                    }
+                    buf.get_mut(x, y)
+                        .set_char('─')
+                        .set_fg(app.theme.peak);
+                }
+            } else if row < bar_rows && bar_rows > 0 {
+                // Color based on absolute position in the panel, not relative
+                // to bar height. Bottom rows are always cool (cyan/green),
+                // top rows are warm (orange/red). Short bars stay cool.
+                let frac = row as f32 / display_h as f32;
                 let color = if frac < 0.5 {
                     let t = frac / 0.5;
                     Color::Rgb(
@@ -67,9 +85,15 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 };
 
                 let buf = f.buffer_mut();
-                buf.get_mut(x, y)
-                    .set_char('█')
-                    .set_fg(color);
+                for col in 0..bar_w {
+                    let x = bar_x + col;
+                    if x >= inner.x + inner.width {
+                        break;
+                    }
+                    buf.get_mut(x, y)
+                        .set_char('█')
+                        .set_fg(color);
+                }
             }
         }
     }


### PR DESCRIPTION
- Bars now dynamically fill the panel width instead of using a fixed 2-column stride so it looks correct on various sizes (tested on 4k and 1080p monitors)
- Bar heights scale proportionally to available panel rows (the CAVA-style processing still works in its 0–12 logical range internally)
- Gaps between bars scale proportionally so the bar-to-gap ratio stays consistent across resolutions
- Color gradient is now based on absolute position in the panel rather than relative to each bar's height. Meaning, short bars stay cool (cyan/green) while only bars reaching the top go orange/red.