### PR TITLE
Add real-time audio visualizer and process management on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "AetherTune"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "crossterm",
  "libc",
@@ -12,6 +12,7 @@ dependencies = [
  "rand 0.9.2",
  "ratatui",
  "tokio",
+ "wasapi",
 ]
 
 [[package]]
@@ -1162,6 +1163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,7 +1857,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1855,6 +1874,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1992,7 +2022,7 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tracing",
  "url",
@@ -2012,7 +2042,7 @@ dependencies = [
  "parking_lot",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "trust-dns-proto",
 ]
@@ -2110,6 +2140,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "wasapi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7834ac561bea8a7413661fdda62180f9e054f99815269cd3572cf7e40d9c3191"
+dependencies = [
+ "log",
+ "num-integer",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -2264,6 +2307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2338,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2303,6 +2378,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2389,6 +2474,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ rand = "0.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+wasapi = "0.22"

--- a/src/audio/jobobject.rs
+++ b/src/audio/jobobject.rs
@@ -1,0 +1,133 @@
+//! Win32 Job Object wrapper for child process lifecycle management.
+//!
+//! When AetherTune spawns mpv.exe, we assign it to a Job Object with
+//! JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. This ensures mpv is terminated
+//! automatically when AetherTune exits — even on a crash, forced close,
+//! or terminal disconnect. Without this, mpv.exe survives as an orphan.
+
+use std::os::windows::io::AsRawHandle;
+
+// ── Raw Win32 FFI (avoids adding windows-sys as a dependency) ──────────
+
+type HANDLE = *mut std::ffi::c_void;
+type BOOL = i32;
+type DWORD = u32;
+
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE: DWORD = 0x2000;
+const JOB_OBJECT_EXTENDED_LIMIT_INFORMATION: DWORD = 9;
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct JOBOBJECT_BASIC_LIMIT_INFORMATION {
+    PerProcessUserTimeLimit: i64,
+    PerJobUserTimeLimit: i64,
+    LimitFlags: DWORD,
+    MinimumWorkingSetSize: usize,
+    MaximumWorkingSetSize: usize,
+    ActiveProcessLimit: DWORD,
+    Affinity: usize,
+    PriorityClass: DWORD,
+    SchedulingClass: DWORD,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct IO_COUNTERS {
+    ReadOperationCount: u64,
+    WriteOperationCount: u64,
+    OtherOperationCount: u64,
+    ReadTransferCount: u64,
+    WriteTransferCount: u64,
+    OtherTransferCount: u64,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+    BasicLimitInformation: JOBOBJECT_BASIC_LIMIT_INFORMATION,
+    IoInfo: IO_COUNTERS,
+    ProcessMemoryLimit: usize,
+    JobMemoryLimit: usize,
+    PeakProcessMemoryUsed: usize,
+    PeakJobMemoryUsed: usize,
+}
+
+unsafe extern "system" {
+    fn CreateJobObjectW(
+        lpJobAttributes: HANDLE,
+        lpName: *const u16,
+    ) -> HANDLE;
+
+    fn SetInformationJobObject(
+        hJob: HANDLE,
+        JobObjectInformationClass: DWORD,
+        lpJobObjectInformation: *const std::ffi::c_void,
+        cbJobObjectInformationLength: DWORD,
+    ) -> BOOL;
+
+    fn AssignProcessToJobObject(
+        hJob: HANDLE,
+        hProcess: HANDLE,
+    ) -> BOOL;
+
+    fn CloseHandle(hObject: HANDLE) -> BOOL;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/// A Win32 Job Object configured to kill all assigned processes when dropped.
+pub struct JobObject {
+    handle: HANDLE,
+}
+
+// SAFETY: Job Object handles are kernel handles with no thread affinity.
+unsafe impl Send for JobObject {}
+
+impl JobObject {
+    /// Create a new Job Object with KILL_ON_JOB_CLOSE.
+    /// Returns None if the Win32 calls fail (shouldn't happen on any
+    /// supported Windows version).
+    pub fn new() -> Option<Self> {
+        unsafe {
+            let handle = CreateJobObjectW(std::ptr::null_mut(), std::ptr::null());
+            if handle.is_null() {
+                return None;
+            }
+
+            let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            let result = SetInformationJobObject(
+                handle,
+                JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+                &info as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+            );
+
+            if result == 0 {
+                CloseHandle(handle);
+                return None;
+            }
+
+            Some(JobObject { handle })
+        }
+    }
+
+    /// Assign a child process to this Job Object.
+    /// Once assigned, the process will be killed when this JobObject is dropped.
+    pub fn assign(&self, child: &std::process::Child) {
+        unsafe {
+            let process_handle = child.as_raw_handle() as HANDLE;
+            AssignProcessToJobObject(self.handle, process_handle);
+        }
+    }
+}
+
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        unsafe {
+            // Closing the handle with KILL_ON_JOB_CLOSE kills all assigned processes
+            CloseHandle(self.handle);
+        }
+    }
+}

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -3,3 +3,8 @@ pub mod fft;
 pub mod pipe;
 pub mod player;
 pub mod visualizer;
+
+#[cfg(windows)]
+pub mod wasapi_capture;
+#[cfg(windows)]
+pub mod jobobject;

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -11,6 +11,11 @@ use std::os::unix::process::CommandExt;
 use crate::audio::pipe as audio_pipe;
 use crate::audio::pipe::SharedAnalysis;
 
+#[cfg(windows)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(windows)]
+use std::sync::Arc;
+
 pub struct StreamInfo {
     /// Actual audio bitrate in bits/sec from mpv (0 if unknown)
     pub audio_bitrate: f64,
@@ -76,6 +81,15 @@ pub struct Player {
     /// FIFO path for parec -> reader communication (Unix only)
     #[cfg(unix)]
     fifo_path: Option<PathBuf>,
+    /// WASAPI loopback capture thread (Windows only)
+    #[cfg(windows)]
+    capture_handle: Option<std::thread::JoinHandle<()>>,
+    /// Stop flag for the WASAPI capture thread (Windows only)
+    #[cfg(windows)]
+    capture_stop: Arc<AtomicBool>,
+    /// Job Object that ensures mpv.exe dies when AetherTune exits (Windows only)
+    #[cfg(windows)]
+    job_object: Option<crate::audio::jobobject::JobObject>,
     socket_path: PathBuf,
     /// IPC stream to mpv (Unix socket on Linux)
     #[cfg(unix)]
@@ -115,6 +129,12 @@ impl Player {
             reader_handle: None,
             #[cfg(unix)]
             fifo_path: None,
+            #[cfg(windows)]
+            capture_handle: None,
+            #[cfg(windows)]
+            capture_stop: Arc::new(AtomicBool::new(false)),
+            #[cfg(windows)]
+            job_object: crate::audio::jobobject::JobObject::new(),
             socket_path,
             #[cfg(unix)]
             stream: None,
@@ -134,7 +154,7 @@ impl Player {
         #[cfg(unix)]
         { self.capture.is_some() }
         #[cfg(windows)]
-        { false }
+        { self.capture_handle.is_some() }
     }
 
     pub fn play_url(&mut self, url: &str, volume: u32) -> bool {
@@ -156,6 +176,14 @@ impl Player {
 
         match cmd.spawn() {
             Ok(c) => {
+                // On Windows, assign mpv to the Job Object so it dies with us
+                #[cfg(windows)]
+                {
+                    if let Some(ref job) = self.job_object {
+                        job.assign(&c);
+                    }
+                }
+
                 self.process = Some(c);
                 self.media_title = None;
                 self.stream_info.reset();
@@ -173,6 +201,15 @@ impl Player {
                         self.start_capture();
                     }
                 }
+
+                // On Windows, start WASAPI loopback capture if visualizer is enabled
+                #[cfg(windows)]
+                {
+                    if self.visualizer_enabled {
+                        self.start_capture();
+                    }
+                }
+
                 true
             }
             Err(_) => false,
@@ -222,6 +259,18 @@ impl Player {
         }
     }
 
+    /// Start WASAPI loopback capture for real-time audio visualization.
+    #[cfg(windows)]
+    fn start_capture(&mut self) {
+        // Reset the stop flag and spawn the capture thread
+        self.capture_stop.store(false, Ordering::Relaxed);
+        let handle = crate::audio::wasapi_capture::spawn_capture_thread(
+            self.analysis.clone(),
+            self.capture_stop.clone(),
+        );
+        self.capture_handle = Some(handle);
+    }
+
     #[cfg(unix)]
     fn stop_capture(&mut self) {
         if let Some(mut cap) = self.capture.take() {
@@ -255,7 +304,25 @@ impl Player {
 
     #[cfg(windows)]
     fn stop_capture(&mut self) {
-        // No capture on Windows yet
+        // Signal the capture thread to stop
+        self.capture_stop.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.capture_handle.take() {
+            // Give the thread a moment to exit cleanly
+            let start = std::time::Instant::now();
+            loop {
+                if handle.is_finished() {
+                    let _ = handle.join();
+                    break;
+                }
+                if start.elapsed() > std::time::Duration::from_millis(300) {
+                    break; // Don't block shutdown
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+        }
+
+        self.analysis.write(crate::audio::pipe::AudioAnalysis::new());
     }
 
     /// Stop audio capture if it's currently running (called when visualizer is disabled)
@@ -266,6 +333,12 @@ impl Player {
                 self.stop_capture();
             }
         }
+        #[cfg(windows)]
+        {
+            if self.capture_handle.is_some() {
+                self.stop_capture();
+            }
+        }
     }
 
     /// Restart audio capture (called when visualizer is re-enabled while playing)
@@ -273,6 +346,12 @@ impl Player {
         #[cfg(unix)]
         {
             if self.has_parec && self.capture.is_none() && self.process.is_some() {
+                self.start_capture();
+            }
+        }
+        #[cfg(windows)]
+        {
+            if self.capture_handle.is_none() && self.process.is_some() {
                 self.start_capture();
             }
         }

--- a/src/audio/wasapi_capture.rs
+++ b/src/audio/wasapi_capture.rs
@@ -1,0 +1,189 @@
+//! Windows-only WASAPI loopback audio capture.
+//!
+//! Captures whatever is playing through the default output device and
+//! feeds it through the same FFT → band grouping → SeqLock pipeline
+//! that the Unix parec/FIFO path uses. The visualizer doesn't need to
+//! know which backend provided the data.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use crate::audio::fft::{self, FFT_SIZE, MAGNITUDE_COUNT};
+use crate::audio::pipe::{AudioAnalysis, SharedAnalysis, NUM_BANDS};
+
+/// Spawn a background thread that captures system audio via WASAPI loopback.
+///
+/// The thread runs until `stop` is set to true. On any error (no audio
+/// device, COM failure, etc.) the thread exits silently and the visualizer
+/// falls back to simulated mode automatically.
+pub fn spawn_capture_thread(
+    analysis: SharedAnalysis,
+    stop: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        // Errors are non-fatal — the visualizer just stays in simulated mode
+        let _ = capture_loop(&analysis, &stop);
+        analysis.write(AudioAnalysis::new());
+    })
+}
+
+fn capture_loop(
+    analysis: &SharedAnalysis,
+    stop: &AtomicBool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize COM on this thread (multi-threaded apartment)
+    wasapi::initialize_mta()?;
+
+    // Get the default output (render) device — capturing from it gives us
+    // loopback audio (whatever is playing through the speakers)
+    let enumerator = wasapi::DeviceEnumerator::new()?;
+    let device = enumerator.get_default_device(&wasapi::Direction::Render)?;
+    let mut audio_client = device.get_iaudioclient()?;
+
+    // Query the device's native mix format — loopback capture delivers
+    // audio in this format regardless of what we request
+    let mix_format = audio_client.get_mixformat()?;
+    let channels = mix_format.get_nchannels() as usize;
+    let bits_per_sample = mix_format.get_bitspersample() as usize;
+    let block_align = mix_format.get_blockalign() as usize;
+    let bytes_per_sample = bits_per_sample / 8;
+
+    // Initialize for loopback capture (shared mode, event-driven)
+    // Direction::Capture on a Render device = loopback
+    let (def_period, _min_period) = audio_client.get_device_period()?;
+    audio_client.initialize_client(
+        &mix_format,
+        &wasapi::Direction::Capture,
+        &wasapi::StreamMode::EventsShared {
+            autoconvert: true,
+            buffer_duration_hns: def_period,
+        },
+    )?;
+
+    let h_event = audio_client.set_get_eventhandle()?;
+    let capture_client = audio_client.get_audiocaptureclient()?;
+    audio_client.start_stream()?;
+
+    // ── FFT processing state (same pipeline as the Unix reader_loop) ──
+
+    // Sliding window: we accumulate samples and run FFT every half-window,
+    // giving ~94 updates/sec at 48kHz (same as the FIFO path).
+    let half = FFT_SIZE / 2;
+    let mut mono_samples = vec![0.0f64; FFT_SIZE];
+    let mut sample_pos = half; // start half-full for sliding window
+
+    // Pre-allocated FFT work buffers
+    let mut fft_re = vec![0.0f64; FFT_SIZE];
+    let mut fft_im = vec![0.0f64; FFT_SIZE];
+    let mut magnitudes = vec![0.0f64; MAGNITUDE_COUNT];
+
+    // Pre-compute Hann window and band edges
+    let hann: Vec<f64> = (0..FFT_SIZE)
+        .map(|i| {
+            0.5 * (1.0
+                - (2.0 * std::f64::consts::PI * i as f64 / (FFT_SIZE - 1) as f64).cos())
+        })
+        .collect();
+    let band_edges = fft::compute_band_edges();
+    let mut fft_count: u64 = 0;
+
+    loop {
+        if stop.load(Ordering::Relaxed) {
+            break;
+        }
+
+        // Wait for audio data (100ms timeout so we can check the stop flag)
+        if h_event.wait_for_event(100_000).is_err() {
+            continue;
+        }
+
+        // Drain all available packets (there may be more than one after an event)
+        loop {
+            let packet_size = match capture_client.get_next_packet_size() {
+                Ok(Some(n)) if n > 0 => n as usize,
+                _ => break,
+            };
+
+            let data = match capture_client.read_from_device(packet_size) {
+                Ok(d) => d,
+                Err(_) => break,
+            };
+
+            // Convert each frame to mono f64
+            for frame in 0..packet_size {
+                let offset = frame * block_align;
+
+                let mono = if bits_per_sample == 32 {
+                    // f32 samples (standard on modern Windows)
+                    let mut sum = 0.0f64;
+                    for ch in 0..channels {
+                        let o = offset + ch * bytes_per_sample;
+                        if o + 4 <= data.len() {
+                            let s = f32::from_le_bytes([
+                                data[o],
+                                data[o + 1],
+                                data[o + 2],
+                                data[o + 3],
+                            ]);
+                            sum += s as f64;
+                        }
+                    }
+                    sum / channels as f64
+                } else if bits_per_sample == 16 {
+                    // s16le samples (older devices)
+                    let mut sum = 0.0f64;
+                    for ch in 0..channels {
+                        let o = offset + ch * bytes_per_sample;
+                        if o + 2 <= data.len() {
+                            let s = i16::from_le_bytes([data[o], data[o + 1]]);
+                            sum += s as f64 / 32768.0;
+                        }
+                    }
+                    sum / channels as f64
+                } else {
+                    0.0
+                };
+
+                mono_samples[sample_pos] = mono;
+                sample_pos += 1;
+
+                // When the window is full, run FFT and slide
+                if sample_pos >= FFT_SIZE {
+                    let rms = {
+                        let sum_sq: f64 = mono_samples.iter().map(|s| s * s).sum();
+                        (sum_sq / FFT_SIZE as f64).sqrt()
+                    };
+
+                    for i in 0..FFT_SIZE {
+                        fft_re[i] = mono_samples[i] * hann[i];
+                        fft_im[i] = 0.0;
+                    }
+
+                    fft::fft_in_place(&mut fft_re, &mut fft_im);
+
+                    for i in 0..MAGNITUDE_COUNT {
+                        magnitudes[i] = (fft_re[i] * fft_re[i] + fft_im[i] * fft_im[i]).sqrt()
+                            / FFT_SIZE as f64;
+                    }
+
+                    let band_energies = fft::group_into_bands(&magnitudes, &band_edges);
+
+                    fft_count += 1;
+                    analysis.write(AudioAnalysis {
+                        active: true,
+                        rms,
+                        bands: band_energies,
+                        fft_count,
+                    });
+
+                    // Slide: keep second half, discard first
+                    mono_samples.copy_within(half.., 0);
+                    sample_pos = half;
+                }
+            }
+        }
+    }
+
+    audio_client.stop_stream()?;
+    Ok(())
+}


### PR DESCRIPTION
Replace the simulated sine-wave visualizer on Windows with real-time audio capture via WASAPI loopback, and fix orphaned `mpv.exe` processes.

== WASAPI loopback capture (`audio/wasapi_capture.rs`) ==

Captures whatever is playing through the default output device using Windows Audio Session API in loopback mode. The captured PCM samples feed directly into the existing FFT - band grouping - SeqLock pipeline from `fft.rs` and `pipe.rs` to the visualizer doesn't know or care which backend provided the data.

- Event-driven capture with 100ms timeout for clean shutdown
- Handles f32 (modern devices) and s16le (legacy) sample formats
- Down mixes any channel count to mono
- Sliding window FFT at ~94 updates/sec (same rate as Unix `parec` path)
- Zero user-facing dependencies as WASAPI is built into Windows as a crate

== Job Object for `mpv.exe` lifecycle (`audio/jobobject.rs`) ==

Wraps `mpv.exe` in a Win32 Job Object with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. This ensures `mpv` is terminated automatically when AetherTune exits, even on crash, forced close, or terminal disconnect. Previously `mpv.exe` would survive as an orphan process.

Uses raw FFI (3 Win32 calls) to avoid adding windows-sys as a dependency.

== Integration (`player.rs`) ==

- Windows capture start/stop wired into `play_url()` and `stop()`
- `has_real_audio()` now returns true on Windows when capture is running
- `stop_capture_if_running()` and `restart_capture()` work on both platforms
- Job Object assigned to mpv immediately after spawn

All new code is behind `#[cfg(windows)]` so that zero changes are made to the Unix path.

Dependency: wasapi = "0.22" (Windows only, cfg-gated in `Cargo.toml`)

Closes #5