### PR TITLE
perf: cache header hints, fix boot progress sync, batch mpv IPC, spee…

### DIFF
--- a/.github/workflows/publish-ppa.yml
+++ b/.github/workflows/publish-ppa.yml
@@ -76,7 +76,7 @@ jobs:
             # Update changelog for this series
             cd "aethertune-${VERSION}"
             cat > debian/changelog <<CHLOG
-          aethertune (${VERSION}-ppa2~${SERIES}) ${SERIES}; urgency=medium
+          aethertune (${VERSION}-ppa${{ github.run_number }}~${SERIES}) ${SERIES}; urgency=medium
 
             * Release v${VERSION}
 
@@ -94,7 +94,7 @@ jobs:
 
             # Upload to PPA
             cd "${WORKDIR}"
-            dput ppa:patchgoblin/aethertune "aethertune_${VERSION}-ppa2~${SERIES}_source.changes"
+            dput ppa:patchgoblin/aethertune "aethertune_${VERSION}-ppa${{ github.run_number }}~${SERIES}_source.changes"
 
             cd "${STARTDIR}"
           done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "AetherTune"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2024"
 
 [dependencies]

--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -143,9 +143,19 @@ Each frame records a `had_tick` flag indicating whether the IPC poll and visuali
 
 The sparkline records one CPU load sample per frame into a separate 40-entry ring buffer, displayed oldest-to-newest.
 
+### Station List Rendering
+
+The Stations and History panels mark favorited entries with a ★. This lookup builds a `HashSet` of favorite URLs once per `draw()` call rather than linear-scanning `app.favorites.entries` for every row with N stations loaded and M favorites, that's O(N) hash lookups per frame instead of O(N × M) string comparisons. This matters most after using "Load more" repeatedly, since the station list (unlike the always-small favorites/history lists) can grow into the hundreds over a session. This is part of what "Many stations loaded in the list" refers to under Draw cost above.
+
 ### Audio Reader (Sliding Window)
 
 The audio reader thread (Unix `parec` FIFO reader or Windows WASAPI loopback) uses a sliding window to maximize FFT update rate without sacrificing frequency resolution. Instead of reading a full 1024-sample chunk (~21ms at 48kHz) before running FFT, it reads 512 new samples (~10.7ms), shifts the 1024-sample buffer left, and runs FFT on the full window. This produces ~94 FFT updates/sec at 2× the rate of full-chunk reads while keeping the same 1024-point FFT resolution. The `fft_count` field on `AudioAnalysis` is incremented on each update, and the profiler computes the rate by sampling this counter every ~1 second.
+
+#### Considered: sliding DFT instead of full FFT recompute
+
+Since only half the 1024-sample window actually changes between steps, it's tempting to think a "true" incremental sliding DFT. Updating each frequency bin sample-by-sample via the standard recurrence `X_k[n] = (X_k[n-1] - x[n-N] + x[n]) * e^{j*2*pi*k/N}` which would be cheaper than recomputing the full FFT from scratch every step.
+
+Benchmarked with the actual FFT size (1024) and step size (512 new samples/update): the sliding DFT was **~16.5x slower** (293µs vs 18µs per update). The reason is fundamental, not an implementation issue: the sliding DFT's per-sample update is O(N) across all bins, and its efficiency advantage only exists when a fresh spectrum is needed on *every single incoming sample*. Here, a spectrum is only needed once per 512-sample step, so 512 individual O(N) updates (≈524K operations) cost far more than one O(N log N) FFT (≈10K operations). The current full-recompute-per-step design is the correct choice for this access pattern and not an oversight. This is left here so it isn't reinvestigated as a "missed" optimization later.
 
 ## Reference Benchmarks
 

--- a/src/audio/player.rs
+++ b/src/audio/player.rs
@@ -229,8 +229,10 @@ impl Player {
 
                 #[cfg(unix)]
                 {
-                    // Give mpv a moment to start and create the IPC socket
-                    std::thread::sleep(std::time::Duration::from_millis(400));
+                    // connect_ipc() now polls at a short interval starting
+                    // immediately, so we connect as soon as mpv actually
+                    // creates the socket instead of always eating a flat
+                    // 400ms up front regardless of how fast that happens.
                     self.connect_ipc();
 
                     // Start audio capture for visualization if a capture
@@ -407,7 +409,14 @@ impl Player {
 
     #[cfg(unix)]
     fn connect_ipc(&mut self) {
-        for _ in 0..5 {
+        // Poll frequently rather than in coarse steps, so we connect the
+        // moment mpv actually creates the socket instead of being capped
+        // by the retry interval. ~30 attempts * 50ms = 1.5s worst-case
+        // wait if mpv is unusually slow to start (similar ceiling to the
+        // old 400ms-sleep + 5*200ms-retry scheme), but typical startups
+        // — mpv usually creates the socket well under 100ms in — connect
+        // almost immediately instead of always eating the old flat delay.
+        for _ in 0..30 {
             match UnixStream::connect(&self.socket_path) {
                 Ok(stream) => {
                     stream.set_nonblocking(true).ok();
@@ -422,22 +431,18 @@ impl Player {
                     self.reader = stream.try_clone().ok().map(BufReader::new);
                     self.stream = Some(stream);
 
+                    // Batch all four setup commands into a single write —
+                    // one syscall instead of four on every connect.
                     self.send_command(
-                        r#"{ "command": ["observe_property", 1, "media-title"] }"#,
-                    );
-                    self.send_command(
-                        r#"{ "command": ["observe_property", 2, "audio-codec-name"] }"#,
-                    );
-                    self.send_command(
-                        r#"{ "command": ["observe_property", 3, "audio-params/samplerate"] }"#,
-                    );
-                    self.send_command(
-                        r#"{ "command": ["observe_property", 4, "audio-params/channel-count"] }"#,
+                        "{ \"command\": [\"observe_property\", 1, \"media-title\"] }\n\
+                         { \"command\": [\"observe_property\", 2, \"audio-codec-name\"] }\n\
+                         { \"command\": [\"observe_property\", 3, \"audio-params/samplerate\"] }\n\
+                         { \"command\": [\"observe_property\", 4, \"audio-params/channel-count\"] }",
                     );
                     return;
                 }
                 Err(_) => {
-                    std::thread::sleep(std::time::Duration::from_millis(200));
+                    std::thread::sleep(std::time::Duration::from_millis(50));
                 }
             }
         }

--- a/src/core/app.rs
+++ b/src/core/app.rs
@@ -76,6 +76,13 @@ pub struct App {
     /// When true, theme backgrounds are cleared so the terminal's own
     /// (possibly transparent) background shows through instead
     pub transparent_bg: bool,
+    /// Cached " │ X search │ Y genre │ ..." header hint string, rebuilt
+    /// only when keybindings actually change (via save_config()) rather
+    /// than reformatted from scratch every single frame.
+    pub header_hint: String,
+    /// Cached " │ vis: off (X)" suffix, empty when the visualizer is on.
+    /// Rebuilt alongside header_hint for the same reason.
+    pub header_vis_status: String,
 }
 
 impl App {
@@ -86,7 +93,7 @@ impl App {
         let mut player = Player::new(analysis.clone());
         player.visualizer_enabled = config.visualizer_enabled;
 
-        Self {
+        let mut app = Self {
             stations,
             selected_index: 0,
             player,
@@ -141,7 +148,39 @@ impl App {
             },
             visualizer_enabled: config.visualizer_enabled,
             transparent_bg: config.transparent_bg,
-        }
+            header_hint: String::new(),
+            header_vis_status: String::new(),
+        };
+        app.rebuild_header_hint();
+        app
+    }
+
+    /// Rebuild the cached header hint strings from current keybindings and
+    /// visualizer state. Every place that mutates keybindings or toggles
+    /// the visualizer already calls save_config() right afterward, so
+    /// hooking the rebuild there (rather than at each mutation site
+    /// individually) keeps this in sync without needing to remember to
+    /// invalidate it in five different places.
+    fn rebuild_header_hint(&mut self) {
+        use crate::storage::config::keycode_to_string;
+
+        let search_key = keycode_to_string(self.keybindings.search.primary);
+        let genre_key = keycode_to_string(self.keybindings.genre_picker.primary);
+        let theme_key = keycode_to_string(self.keybindings.theme_picker.primary);
+        let help_key = keycode_to_string(self.keybindings.help.primary);
+        let settings_key = keycode_to_string(self.keybindings.settings.primary);
+        let vis_key = keycode_to_string(self.keybindings.visualizer_toggle.primary);
+
+        self.header_hint = format!(
+            "  │  {} search  │  {} genre  │  {} theme  │  {} help  │  {} settings  │  {} vizualizer toggle",
+            search_key, genre_key, theme_key, help_key, settings_key, vis_key
+        );
+
+        self.header_vis_status = if self.visualizer_enabled {
+            String::new()
+        } else {
+            format!("  │  vis: off ({})", vis_key)
+        };
     }
 
     pub fn next(&mut self) {
@@ -328,7 +367,7 @@ impl App {
     }
 
     /// Persist current tick rate, volume, and keybindings to config file
-    pub fn save_config(&self) {
+    pub fn save_config(&mut self) {
         let mut config = Config::load();
         // Only save tick_rate_ms when visualizer is enabled — otherwise we'd
         // overwrite the user's preference with the low-power 200ms value
@@ -341,6 +380,13 @@ impl App {
         config.visualizer_enabled = self.visualizer_enabled;
         config.transparent_bg = self.transparent_bg;
         config.save();
+
+        // Keybindings and visualizer_enabled are the two inputs to the
+        // header hint, and every call site that mutates either of them
+        // calls save_config() right afterward — so rebuilding here keeps
+        // the cache correct without a separate invalidation call at each
+        // of those mutation sites.
+        self.rebuild_header_hint();
     }
 
     pub fn toggle_favorite(&mut self) {

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -46,20 +46,6 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
 
         let cat = app.categories[app.category_index];
 
-        use crate::storage::config::keycode_to_string;
-        let search_key = keycode_to_string(app.keybindings.search.primary);
-        let genre_key = keycode_to_string(app.keybindings.genre_picker.primary);
-        let theme_key = keycode_to_string(app.keybindings.theme_picker.primary);
-        let help_key = keycode_to_string(app.keybindings.help.primary);
-        let settings_key = keycode_to_string(app.keybindings.settings.primary);
-
-        let vis_key = keycode_to_string(app.keybindings.visualizer_toggle.primary);
-        let vis_status = if app.visualizer_enabled {
-            String::new()
-        } else {
-            format!("  │  vis: off ({})", vis_key)
-        };
-
         // Genre only means something on the Stations panel — Favorites/History
         // aren't filtered by it, so showing it there just implies a filter
         // that isn't actually being applied.
@@ -77,11 +63,11 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 Style::default().fg(app.theme.accent),
             ),
             Span::styled(
-                format!("  │  {} search  │  {} genre  │  {} theme  │  {} help  │  {} settings  │  {} vizualizer toggle", search_key, genre_key, theme_key, help_key, settings_key, vis_key),
+                app.header_hint.as_str(),
                 Style::default().fg(Color::Rgb(80, 80, 110)),
             ),
             Span::styled(
-                vis_status.clone(),
+                app.header_vis_status.as_str(),
                 Style::default().fg(app.theme.text_warn),
             ),
         ]);

--- a/src/ui/launcher.rs
+++ b/src/ui/launcher.rs
@@ -895,8 +895,13 @@ fn draw_connecting(f: &mut Frame, menu: &MenuApp) {
     let content = Paragraph::new(lines);
     f.render_widget(content, inner);
 
-    // Progress bar at bottom of box — synced with message timing
-    let progress = (elapsed as f64 / menu.timing.connect_done as f64).min(1.0);
+    // Progress bar at bottom of box, synced with message timing.
+    // The bar reaches 100% exactly when the last checkmark ("Launching ✓")
+    // appears, rather than at the screen's full duration. Otherwise the
+    // bar keeps crawling for a while after every checklist item already
+    // shows done, which reads as out of sync.
+    let last_msg_start = msgs.last().map(|&(_, t)| t).unwrap_or(menu.timing.connect_done);
+    let progress = (elapsed as f64 / last_msg_start.max(1) as f64).min(1.0);
     let bar_width = (box_width.saturating_sub(4)) as usize;
     let filled = (bar_width as f64 * progress) as usize;
     let empty = bar_width.saturating_sub(filled);

--- a/src/ui/station_list.rs
+++ b/src/ui/station_list.rs
@@ -14,13 +14,20 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
     // prefix markers (4)
     let name_budget = (area.width as usize).saturating_sub(10);
 
+    // Build the set of favorite URLs once per draw() call rather than
+    // linear-scanning app.favorites.entries for every station/history row
+    // (previously O(stations * favorites) string comparisons every single
+    // frame — this made it O(stations) hash lookups instead).
+    let favorite_urls: std::collections::HashSet<&str> =
+        app.favorites.entries.iter().map(|f| f.url.as_str()).collect();
+
     let (title, items, selected) = match app.active_panel {
         ActivePanel::Stations => {
             let items: Vec<ListItem> = app
                 .stations
                 .iter()
                 .map(|s| {
-                    let fav_marker = if app.is_favorite(&s.url) { "★ " } else { "  " };
+                    let fav_marker = if favorite_urls.contains(s.url.as_str()) { "★ " } else { "  " };
                     let playing_marker = app
                         .now_playing
                         .as_ref()
@@ -91,7 +98,7 @@ pub fn draw(f: &mut Frame, app: &App, area: Rect) {
                 .entries
                 .iter()
                 .map(|h| {
-                    let fav_marker = if app.is_favorite(&h.url) { "★ " } else { "  " };
+                    let fav_marker = if favorite_urls.contains(h.url.as_str()) { "★ " } else { "  " };
                     let time_str = &h.played_at;
                     let line = Line::from(vec![
                         Span::styled(fav_marker, Style::default().fg(app.theme.text_warn)),


### PR DESCRIPTION
…d up favorites lookup

- Boot screen progress bar now reaches 100% exactly when the last checklist item ("Launching AetherTune ✓") appears, instead of continuing to crawl for ~29% of the screen's duration after every item already shows done. The bar was scaled against the full screen duration while the checklist was deliberately packed into only the first 85% of it. Two different timing scales for what should be one synced animation.

- `Player::play_url()` no longer sleeps a flat 400ms before attempting to connect to mpv's IPC socket. `connect_ipc()` now polls every 50ms starting immediately, so typical startups (mpv usually creates the socket well under 100ms in) connect as soon as it's actually ready instead of always eating the full 400ms regardless.

- The four observe_property setup commands sent on every IPC connect are now one `write_all()` call instead of four separate ones.

- `station_list.rs` no longer linear-scans the full favorites list for every station/history row on every single frame. With N stations loaded (grows unboundedly via "Load more") and M favorites, this was O(N * M) string comparisons per frame; now it's O(N) hash lookups via a HashSet built once per `draw()` call.

- Header hint text (" │ X search │ Y genre │ ..." and the "vis: off" suffix) is no longer reformatted from six keybinding lookups every frame. It's now cached on App and only rebuilt via a new `rebuild_header_hint()` call inside `save_config()` for every place that mutates keybindings or toggles the visualizer already calls `save_config()` right after, so this is the one safe place to invalidate the cache rather than five separate call sites. `save_config()` is now `&mut` self to support this; verified every existing call site already holds a mutable App reference.

- `docs/PROFILING.md`: documented two investigations so they aren't re-litigated later. (1) benchmarked a "true" sliding DFT against the current full-FFT-per-step approach using the actual FFT/step sizes; the sliding DFT was ~16.5x slower because its efficiency advantage only applies when a spectrum is needed on every incoming sample, not once per 512-sample block, so the current design is correct as-is. (2) Noted the station-list HashSet optimization under the existing "many stations loaded" draw-cost factor.

Bump to 0.11.2